### PR TITLE
4.2.2 Release 

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -96,13 +96,11 @@ $rules = [
 
     'header_comment' => [
         'header'       => $header,
-        'separate'     => 'bottom',
-        'comment_type' => 'PHPDoc',
     ]
 ];
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__ . '/src');
+    ->in([__DIR__ . '/src', __DIR__ . '/tests']);
 
 return PhpCsFixer\Config::create()
     ->setRules($rules)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Develop
-- Fix error if custom validator doesn't provides a message
+- Fix error if custom validator doesn't provides a message.
+- Removed broken and deprecated `RequestSchema::loadSchema` method.
 
 ## [4.2.1] - 2019-01-13
 - Fix issue with ResourceLocator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Develop
+- Fix error if custom validator doesn't provides a message
+
 ## [4.2.1] - 2019-01-13
 - Fix issue with ResourceLocator
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Develop
+## [4.2.2] - 2019-03-28
 - Fix error if custom validator doesn't provides a message.
 - Removed broken and deprecated `RequestSchema::loadSchema` method.
+- 100% Test coverage ([#24])
 
 ## [4.2.1] - 2019-01-13
 - Fix issue with ResourceLocator
@@ -38,6 +39,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Implement equals, not_equals, telephone, uri, and username rules
 
 
+[4.2.2]: https://github.com/userfrosting/fortress/compare/4.2.1...4.2.2
 [4.2.1]: https://github.com/userfrosting/fortress/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/userfrosting/fortress/compare/4.1.2...4.2.0
 [4.1.3]: https://github.com/userfrosting/fortress/compare/4.1.2...4.1.3
@@ -45,3 +47,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 [4.1.1]: https://github.com/userfrosting/fortress/compare/4.1.0...v4.1.1
 [4.1.0]: https://github.com/userfrosting/fortress/compare/4.0.1...4.1.0
 [4.0.1]: https://github.com/userfrosting/fortress/compare/4.0.0...4.0.1
+[#24]: https://github.com/userfrosting/fortress/issues/24

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 | Branch | Build | Coverage | Style |
 | ------ |:-----:|:--------:|:-----:|
-| [master][Fortress]  | [![][fortress-master-build]][fortress-travis] | [![][fortress-master-codecov]][fortress-codecov] | [![][config-style-master]][config-style] |
-| [develop][fortress-develop] | [![][fortress-develop-build]][fortress-travis] | [![][fortress-develop-codecov]][fortress-codecov] | [![][config-style-develop]][config-style] |
+| [master][Fortress]  | [![][fortress-master-build]][fortress-travis] | [![][fortress-master-codecov]][fortress-codecov] | [![][fortress-style-master]][fortress-style] |
+| [develop][fortress-develop] | [![][fortress-develop-build]][fortress-travis] | [![][fortress-develop-codecov]][fortress-codecov] | [![][fortress-style-develop]][fortress-style] |
 
 <!-- Links -->
 [Fortress]: https://github.com/userfrosting/fortress

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ message:
 {
     "require": {
         "php": ">=5.6.0",
-        "userfrosting/fortress": "^4.1.0"
+        "userfrosting/fortress": "^4.2.0"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,28 @@
 
 [![Latest Version](https://img.shields.io/github/release/userfrosting/fortress.svg)](https://github.com/userfrosting/fortress/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/userfrosting/fortress.svg?branch=master)](https://travis-ci.org/userfrosting/fortress)
-[![codecov](https://codecov.io/gh/userfrosting/fortress/branch/master/graph/badge.svg)](https://codecov.io/gh/userfrosting/fortress)
 [![Join the chat at https://chat.userfrosting.com/channel/support](https://demo.rocket.chat/images/join-chat.svg)](https://chat.userfrosting.com/channel/support)
 [![Donate](https://img.shields.io/badge/Open%20Collective-Donate-blue.svg)](https://opencollective.com/userfrosting#backer)
+
+| Branch | Build | Coverage | Style |
+| ------ |:-----:|:--------:|:-----:|
+| [master][Fortress]  | [![][fortress-master-build]][fortress-travis] | [![][fortress-master-codecov]][fortress-codecov] | [![][config-style-master]][config-style] |
+| [develop][fortress-develop] | [![][fortress-develop-build]][fortress-travis] | [![][fortress-develop-codecov]][fortress-codecov] | [![][config-style-develop]][config-style] |
+
+<!-- Links -->
+[Fortress]: https://github.com/userfrosting/fortress
+[fortress-develop]: https://github.com/userfrosting/fortress/tree/develop
+[fortress-version]: https://img.shields.io/github/release/userfrosting/fortress.svg
+[fortress-master-build]: https://travis-ci.org/userfrosting/fortress.svg?branch=master
+[fortress-master-codecov]: https://codecov.io/gh/userfrosting/fortress/branch/master/graph/badge.svg
+[fortress-develop-build]: https://travis-ci.org/userfrosting/fortress.svg?branch=develop
+[fortress-develop-codecov]: https://codecov.io/gh/userfrosting/fortress/branch/develop/graph/badge.svg
+[fortress-releases]: https://github.com/userfrosting/fortress/releases
+[fortress-travis]: https://travis-ci.org/userfrosting/fortress
+[fortress-codecov]: https://codecov.io/gh/userfrosting/fortress
+[fortress-style-master]: https://github.styleci.io/repos/30551954/shield?branch=master&style=flat
+[fortress-style-develop]: https://github.styleci.io/repos/30551954/shield?branch=develop&style=flat
+[fortress-style]: https://github.styleci.io/repos/30551954
 
 If you simply want to show that you like this project, or want to remember it for later, you should **star**, not **fork**, this repository.  Forking is only for when you are ready to create your own copy of the code to work on.
 

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
         "psr-4": {
             "UserFrosting\\Fortress\\": "src"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "UserFrosting\\Fortress\\Tests\\": "tests"
+        }
     }
 }

--- a/src/Adapter/ClientSideValidationAdapter.php
+++ b/src/Adapter/ClientSideValidationAdapter.php
@@ -14,7 +14,7 @@ use UserFrosting\Fortress\RequestSchema\RequestSchemaInterface;
 use UserFrosting\I18n\MessageTranslator;
 
 /**
- * ClientSideValidationAdapter Class
+ * ClientSideValidationAdapter Class.
  *
  * Loads validation rules from a schema and generates client-side rules compatible with a particular client-side (usually Javascript) plugin.
  *
@@ -75,9 +75,11 @@ abstract class ClientSideValidationAdapter
      * Generate and return the validation rules for this specific validation adapter.
      *
      * This method returns a collection of rules, in the format required by the specified plugin.
-     * @param  string $format       The format in which to return the rules.  For example, "json" or "html5".
-     * @param  bool   $stringEncode In the case of JSON rules, specify whether or not to encode the result as a serialized JSON string.
-     * @return mixed  The validation rule collection.
+     *
+     * @param string $format       The format in which to return the rules.  For example, "json" or "html5".
+     * @param bool   $stringEncode In the case of JSON rules, specify whether or not to encode the result as a serialized JSON string.
+     *
+     * @return mixed The validation rule collection.
      */
     abstract public function rules($format = 'json', $stringEncode = true);
 }

--- a/src/Adapter/ClientSideValidationAdapter.php
+++ b/src/Adapter/ClientSideValidationAdapter.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/Adapter/FormValidationAdapter.php
+++ b/src/Adapter/FormValidationAdapter.php
@@ -11,7 +11,7 @@
 namespace UserFrosting\Fortress\Adapter;
 
 /**
- * FormValidationAdapter Class
+ * FormValidationAdapter Class.
  *
  * Loads validation rules from a schema and generates client-side rules compatible with the [FormValidation](http://formvalidation.io) JS plugin.
  *
@@ -35,7 +35,8 @@ class FormValidationAdapter extends ClientSideValidationAdapter
      * Generate FormValidation compatible rules from the specified RequestSchema, as a JSON document.
      * See [this](http://formvalidation.io/getting-started/#calling-plugin) as an example of what this function will generate.
      *
-     * @param  bool         $encode Specify whether to return a PHP array, or a JSON-encoded string.
+     * @param bool $encode Specify whether to return a PHP array, or a JSON-encoded string.
+     *
      * @return string|array Returns either the array of rules, or a JSON-encoded representation of that array.
      */
     public function formValidationRulesJson($encode = true)
@@ -244,13 +245,13 @@ class FormValidationAdapter extends ClientSideValidationAdapter
                 break;
             case 'member_of':
                 if (isset($validator['values'])) {
-                    $params['regexp'] = '^' . implode('|', $validator['values']) . '$';
+                    $params['regexp'] = '^'.implode('|', $validator['values']).'$';
                 }
                 $transformedValidatorJson['regexp'] = $params;
                 break;
             case 'not_member_of':
                 if (isset($validator['values'])) {
-                    $params['regexp'] = '^(?!' . implode('|', $validator['values']) . '$).*$';
+                    $params['regexp'] = '^(?!'.implode('|', $validator['values']).'$).*$';
                 }
                 $transformedValidatorJson['regexp'] = $params;
                 break;

--- a/src/Adapter/FormValidationAdapter.php
+++ b/src/Adapter/FormValidationAdapter.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/Adapter/FormValidationAdapter.php
+++ b/src/Adapter/FormValidationAdapter.php
@@ -43,7 +43,7 @@ class FormValidationAdapter extends ClientSideValidationAdapter
     {
         $clientRules = [];
         $implicitRules = [];
-        foreach ($this->schema->getSchema() as $fieldName => $field) {
+        foreach ($this->schema->all() as $fieldName => $field) {
             $clientRules[$fieldName] = [];
             $clientRules[$fieldName]['validators'] = [];
 
@@ -72,7 +72,7 @@ class FormValidationAdapter extends ClientSideValidationAdapter
     {
         $clientRules = [];
         $implicitRules = [];
-        foreach ($this->schema->getSchema() as $fieldName => $field) {
+        foreach ($this->schema->all() as $fieldName => $field) {
             $fieldRules = '';
             $validators = $field['validators'];
 
@@ -275,8 +275,6 @@ class FormValidationAdapter extends ClientSideValidationAdapter
             $msg = '';
             if (isset($validator['message'])) {
                 $msg = $validator['message'];
-            } else {
-                return $attr;
             }
             $attr .= "$prefix-message=\"$msg\" ";
         }

--- a/src/Adapter/JqueryValidationAdapter.php
+++ b/src/Adapter/JqueryValidationAdapter.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/Adapter/JqueryValidationAdapter.php
+++ b/src/Adapter/JqueryValidationAdapter.php
@@ -11,7 +11,7 @@
 namespace UserFrosting\Fortress\Adapter;
 
 /**
- * JqueryValidationAdapter Class
+ * JqueryValidationAdapter Class.
  *
  * Loads validation rules from a schema and generates client-side rules compatible with the [jQuery Validation](http://http://jqueryvalidation.org) JS plugin.
  *
@@ -23,7 +23,8 @@ class JqueryValidationAdapter extends ClientSideValidationAdapter
      * Generate jQuery Validation compatible rules from the specified RequestSchema, as a JSON document.
      * See [this](https://github.com/jzaefferer/jquery-validation/blob/master/demo/bootstrap/index.html#L168-L209) as an example of what this function will generate.
      *
-     * @param  bool         $stringEncode Specify whether to return a PHP array, or a JSON-encoded string.
+     * @param bool $stringEncode Specify whether to return a PHP array, or a JSON-encoded string.
+     *
      * @return string|array Returns either the array of rules, or a JSON-encoded representation of that array.
      */
     public function rules($format = 'json', $stringEncode = false, $arrayPrefix = '')
@@ -36,7 +37,7 @@ class JqueryValidationAdapter extends ClientSideValidationAdapter
         foreach ($this->schema->all() as $fieldNameO => $field) {
             $fieldNameOnly = $fieldNameO;
             if ($arrayPrefix != '') {
-                $fieldName = $arrayPrefix . '[' . $fieldNameO . ']';
+                $fieldName = $arrayPrefix.'['.$fieldNameO.']';
             } else {
                 $fieldName = $fieldNameO;
             }
@@ -70,7 +71,7 @@ class JqueryValidationAdapter extends ClientSideValidationAdapter
         }
         $result = [
             'rules'    => $clientRules,
-            'messages' => $clientMessages
+            'messages' => $clientMessages,
         ];
 
         if ($stringEncode) {
@@ -107,7 +108,7 @@ class JqueryValidationAdapter extends ClientSideValidationAdapter
                 if (isset($validator['min']) && isset($validator['max'])) {
                     $transformedValidatorJson['rangelength'] = [
                         $validator['min'],
-                        $validator['max']
+                        $validator['max'],
                     ];
                 } elseif (isset($validator['min'])) {
                     $transformedValidatorJson['minlength'] = $validator['min'];
@@ -153,7 +154,7 @@ class JqueryValidationAdapter extends ClientSideValidationAdapter
                 if (isset($validator['min']) && isset($validator['max'])) {
                     $transformedValidatorJson['range'] = [
                         $validator['min'],
-                        $validator['max']
+                        $validator['max'],
                     ];
                 } elseif (isset($validator['min'])) {
                     $transformedValidatorJson['min'] = $validator['min'];

--- a/src/Adapter/JqueryValidationAdapter.php
+++ b/src/Adapter/JqueryValidationAdapter.php
@@ -23,7 +23,9 @@ class JqueryValidationAdapter extends ClientSideValidationAdapter
      * Generate jQuery Validation compatible rules from the specified RequestSchema, as a JSON document.
      * See [this](https://github.com/jzaefferer/jquery-validation/blob/master/demo/bootstrap/index.html#L168-L209) as an example of what this function will generate.
      *
-     * @param bool $stringEncode Specify whether to return a PHP array, or a JSON-encoded string.
+     * @param string $format       (Default: json)
+     * @param bool   $stringEncode Specify whether to return a PHP array, or a JSON-encoded string. (default: false)
+     * @param string $arrayPrefix  (Default: '')
      *
      * @return string|array Returns either the array of rules, or a JSON-encoded representation of that array.
      */

--- a/src/RequestDataTransformer.php
+++ b/src/RequestDataTransformer.php
@@ -14,7 +14,7 @@ use UserFrosting\Fortress\RequestSchema\RequestSchemaInterface;
 use UserFrosting\Support\Exception\BadRequestException;
 
 /**
- * RequestDataTransformer Class
+ * RequestDataTransformer Class.
  *
  * Perform a series of transformations on a set of data fields, as specified by a RequestSchemaInterface.
  *
@@ -78,6 +78,7 @@ class RequestDataTransformer implements RequestDataTransformerInterface
                         break;
                     case 'error':
                         $e = new BadRequestException("The field '$name' is not a valid input field.");
+
                         throw $e;
                         break;
                     case 'skip':
@@ -134,7 +135,8 @@ class RequestDataTransformer implements RequestDataTransformerInterface
     /**
      * Autodetect if a field is an array or scalar, and filter appropriately.
      *
-     * @param  mixed $value
+     * @param mixed $value
+     *
      * @return mixed
      */
     private function escapeHtmlCharacters($value)
@@ -149,7 +151,8 @@ class RequestDataTransformer implements RequestDataTransformerInterface
     /**
      * Autodetect if a field is an array or scalar, and filter appropriately.
      *
-     * @param  mixed $value
+     * @param mixed $value
+     *
      * @return mixed
      */
     private function purgeHtmlCharacters($value)
@@ -164,7 +167,8 @@ class RequestDataTransformer implements RequestDataTransformerInterface
     /**
      * Autodetect if a field is an array or scalar, and filter appropriately.
      *
-     * @param  mixed $value
+     * @param mixed $value
+     *
      * @return mixed
      */
     private function trim($value)

--- a/src/RequestDataTransformer.php
+++ b/src/RequestDataTransformer.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/RequestDataTransformer.php
+++ b/src/RequestDataTransformer.php
@@ -28,7 +28,7 @@ class RequestDataTransformer implements RequestDataTransformerInterface
     protected $schema;
 
     /**
-     * @var HTMLPurifier
+     * @var \HTMLPurifier
      */
     protected $purifier;
 

--- a/src/RequestDataTransformerInterface.php
+++ b/src/RequestDataTransformerInterface.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/RequestDataTransformerInterface.php
+++ b/src/RequestDataTransformerInterface.php
@@ -13,7 +13,7 @@ namespace UserFrosting\Fortress;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaInterface;
 
 /**
- * RequestDataTransformer Interface
+ * RequestDataTransformer Interface.
  *
  * Perform a series of transformations on a set of data fields, as specified by a RequestSchemaInterface.
  *
@@ -34,20 +34,22 @@ interface RequestDataTransformerInterface
      * Example transformations: escape/purge/purify HTML entities
      * Also, set any default values for unspecified fields.
      *
-     * @param  array  $data                      The array of data to be transformed.
-     * @param  string $onUnexpectedVar[optional] Determines what to do when a field is encountered that is not in the schema.  Set to one of:
-     *                                           "allow": Treat the field as any other, allowing the value through.
-     *                                           "error": Raise an exception.
-     *                                           "skip" (default): Quietly ignore the field.  It will not be part of the transformed data array.
-     * @return array  The array of transformed data, mapping field names => values.
+     * @param array  $data                      The array of data to be transformed.
+     * @param string $onUnexpectedVar[optional] Determines what to do when a field is encountered that is not in the schema.  Set to one of:
+     *                                          "allow": Treat the field as any other, allowing the value through.
+     *                                          "error": Raise an exception.
+     *                                          "skip" (default): Quietly ignore the field.  It will not be part of the transformed data array.
+     *
+     * @return array The array of transformed data, mapping field names => values.
      */
     public function transform(array $data, $onUnexpectedVar);
 
     /**
      * Transform a raw field value.
      *
-     * @param  string $name  The name of the field to transform, as specified in the schema.
-     * @param  string $value The value to be transformed.
+     * @param string $name  The name of the field to transform, as specified in the schema.
+     * @param string $value The value to be transformed.
+     *
      * @return string The transformed value.
      */
     public function transformField($name, $value);

--- a/src/RequestSchema.php
+++ b/src/RequestSchema.php
@@ -14,7 +14,7 @@ use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Support\Repository\Loader\YamlFileLoader;
 
 /**
- * RequestSchema Class
+ * RequestSchema Class.
  *
  * Represents a schema for an HTTP request, compliant with the WDVSS standard (https://github.com/alexweissman/wdvss)
  *
@@ -45,6 +45,7 @@ class RequestSchema extends RequestSchemaRepository
 
     /**
      * @deprecated since 4.1
+     *
      * @return array The schema data.
      */
     public function getSchema()
@@ -54,7 +55,9 @@ class RequestSchema extends RequestSchemaRepository
 
     /**
      * @deprecated since 4.1
-     * @param  string    $path Path to the schema file.
+     *
+     * @param string $path Path to the schema file.
+     *
      * @throws Exception The file does not exist or is not a valid format.
      */
     public function loadSchema()

--- a/src/RequestSchema.php
+++ b/src/RequestSchema.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/RequestSchema.php
+++ b/src/RequestSchema.php
@@ -23,7 +23,7 @@ use UserFrosting\Support\Repository\Loader\YamlFileLoader;
 class RequestSchema extends RequestSchemaRepository
 {
     /**
-     * @var UserFrosting\Support\Repository\Loader\FileRepositoryLoader
+     * @var \UserFrosting\Support\Repository\Loader\FileRepositoryLoader
      */
     protected $loader;
 
@@ -44,24 +44,12 @@ class RequestSchema extends RequestSchemaRepository
     }
 
     /**
-     * @deprecated since 4.1
+     * @deprecated since 4.1. Use `all()` instead
      *
      * @return array The schema data.
      */
     public function getSchema()
     {
         return $this->items;
-    }
-
-    /**
-     * @deprecated since 4.1
-     *
-     * @param string $path Path to the schema file.
-     *
-     * @throws Exception The file does not exist or is not a valid format.
-     */
-    public function loadSchema()
-    {
-        return $this->load($path);
     }
 }

--- a/src/RequestSchema/RequestSchemaInterface.php
+++ b/src/RequestSchema/RequestSchemaInterface.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/RequestSchema/RequestSchemaInterface.php
+++ b/src/RequestSchema/RequestSchemaInterface.php
@@ -11,7 +11,7 @@
 namespace UserFrosting\Fortress\RequestSchema;
 
 /**
- * Represents a schema for an HTTP request, compliant with the WDVSS standard (https://github.com/alexweissman/wdvss)
+ * Represents a schema for an HTTP request, compliant with the WDVSS standard (https://github.com/alexweissman/wdvss).
  *
  * @author Alexander Weissman (https://alexanderweissman.com)
  */
@@ -30,6 +30,7 @@ interface RequestSchemaInterface
      * If no key is specified, the items will be merged in starting from the top level of the array.
      * If a key IS specified, items will be merged into that key.
      * Nested keys may be specified using dot syntax.
+     *
      * @param string|null $key
      * @param mixed       $items
      */
@@ -39,8 +40,10 @@ interface RequestSchemaInterface
      * Set the default value for a specified field.
      *
      * If the specified field does not exist in the schema, add it.  If a default already exists for this field, replace it with the value specified here.
-     * @param  string                 $field The name of the field (e.g., "user_name")
-     * @param  string                 $value The new default value for this field.
+     *
+     * @param string $field The name of the field (e.g., "user_name")
+     * @param string $value The new default value for this field.
+     *
      * @return RequestSchemaInterface This schema object.
      */
     public function setDefault($field, $value);
@@ -50,9 +53,11 @@ interface RequestSchemaInterface
      *
      * If the specified field does not exist in the schema, add it.  If a validator with the specified name already exists for the field,
      * replace it with the parameters specified here.
-     * @param  string                 $field         The name of the field for this validator (e.g., "user_name")
-     * @param  string                 $validatorName A validator rule, as specified in https://github.com/alexweissman/wdvss (e.g. "length")
-     * @param  array                  $parameters    An array of parameters, hashed as parameter_name => parameter value (e.g. [ "min" => 50 ])
+     *
+     * @param string $field         The name of the field for this validator (e.g., "user_name")
+     * @param string $validatorName A validator rule, as specified in https://github.com/alexweissman/wdvss (e.g. "length")
+     * @param array  $parameters    An array of parameters, hashed as parameter_name => parameter value (e.g. [ "min" => 50 ])
+     *
      * @return RequestSchemaInterface This schema object.
      */
     public function addValidator($field, $validatorName, array $parameters = []);
@@ -60,8 +65,9 @@ interface RequestSchemaInterface
     /**
      * Remove a validator for a specified field.
      *
-     * @param  string                 $field         The name of the field for this validator (e.g., "user_name")
-     * @param  string                 $validatorName A validator rule, as specified in https://github.com/alexweissman/wdvss (e.g. "length")
+     * @param string $field         The name of the field for this validator (e.g., "user_name")
+     * @param string $validatorName A validator rule, as specified in https://github.com/alexweissman/wdvss (e.g. "length")
+     *
      * @return RequestSchemaInterface This schema object.
      */
     public function removeValidator($field, $validatorName);
@@ -70,8 +76,10 @@ interface RequestSchemaInterface
      * Set a sequence of transformations for a specified field.
      *
      * If the specified field does not exist in the schema, add it.
-     * @param  string                 $field           The name of the field for this transformation (e.g., "user_name")
-     * @param  string|array           $transformations An array of transformations, as specified in https://github.com/alexweissman/wdvss (e.g. "purge")
+     *
+     * @param string       $field           The name of the field for this transformation (e.g., "user_name")
+     * @param string|array $transformations An array of transformations, as specified in https://github.com/alexweissman/wdvss (e.g. "purge")
+     *
      * @return RequestSchemaInterface This schema object.
      */
     public function setTransformations($field, $transformations = []);

--- a/src/RequestSchema/RequestSchemaRepository.php
+++ b/src/RequestSchema/RequestSchemaRepository.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/RequestSchema/RequestSchemaRepository.php
+++ b/src/RequestSchema/RequestSchemaRepository.php
@@ -13,7 +13,7 @@ namespace UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Support\Repository\Repository;
 
 /**
- * Represents a schema for an HTTP request, compliant with the WDVSS standard (https://github.com/alexweissman/wdvss)
+ * Represents a schema for an HTTP request, compliant with the WDVSS standard (https://github.com/alexweissman/wdvss).
  *
  * @author Alexander Weissman (https://alexanderweissman.com)
  */

--- a/src/ServerSideValidator.php
+++ b/src/ServerSideValidator.php
@@ -92,8 +92,7 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
      *
      * @param string $field
      * @param mixed  $value
-     * @param string $targetValue
-     * @param bool   $caseSensitive
+     * @param array  $params
      *
      * @return bool
      */
@@ -115,8 +114,7 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
      *
      * @param string $field
      * @param mixed  $value
-     * @param string $targetValue
-     * @param bool   $caseSensitive
+     * @param array  $params
      *
      * @return bool
      */

--- a/src/ServerSideValidator.php
+++ b/src/ServerSideValidator.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/ServerSideValidator.php
+++ b/src/ServerSideValidator.php
@@ -177,10 +177,14 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
         // Weird way to adapt with Valitron's funky interface
         $params = array_merge([$rule], array_slice(func_get_args(), 2));
         call_user_func_array([$this, 'rule'], $params);
+
         // Set message.  Use Valitron's default message if not specified in the schema.
         if (!$messageSet) {
-            $messageSet = "'".$params[1]."' ".vsprintf(static::$_ruleMessages[$rule], array_slice(func_get_args(), 3));
+            $message = (isset(static::$_ruleMessages[$rule])) ? static::$_ruleMessages[$rule] : null;
+            $message = vsprintf($message, array_slice(func_get_args(), 3));
+            $messageSet = "'{$params[1]}' $message";
         }
+
         $this->message($messageSet);
     }
 

--- a/src/ServerSideValidator.php
+++ b/src/ServerSideValidator.php
@@ -15,7 +15,7 @@ use UserFrosting\I18n\MessageTranslator;
 use Valitron\Validator;
 
 /**
- * ServerSideValidator Class
+ * ServerSideValidator Class.
  *
  * Loads validation rules from a schema and validates a target array of data.
  *
@@ -90,10 +90,11 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
     /**
      * Validate that a field has a particular value.
      *
-     * @param  string $field
-     * @param  mixed  $value
-     * @param  string $targetValue
-     * @param  bool   $caseSensitive
+     * @param string $field
+     * @param mixed  $value
+     * @param string $targetValue
+     * @param bool   $caseSensitive
+     *
      * @return bool
      */
     protected function validateEqualsValue($field, $value, $params)
@@ -112,10 +113,11 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
     /**
      * Validate that a field does NOT have a particular value.
      *
-     * @param  string $field
-     * @param  mixed  $value
-     * @param  string $targetValue
-     * @param  bool   $caseSensitive
+     * @param string $field
+     * @param mixed  $value
+     * @param string $targetValue
+     * @param bool   $caseSensitive
+     *
      * @return bool
      */
     protected function validateNotEqualsValue($field, $value, $params)
@@ -125,7 +127,7 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
 
     /**
      * Matches US phone number format
-     * Ported from jqueryValidation rules
+     * Ported from jqueryValidation rules.
      *
      * where the area code may not start with 1 and the prefix may not start with 1
      * allows '-' or ' ' as a separator and allows parens around area code
@@ -140,8 +142,9 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
      * and not
      * 212 123 4567
      *
-     * @param  string $field
-     * @param  mixed  $value
+     * @param string $field
+     * @param mixed  $value
+     *
      * @return bool
      */
     protected function validatePhoneUS($field, $value)
@@ -153,10 +156,11 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
     }
 
     /**
-     * Validate that a field contains only valid username characters: alpha-numeric characters, dots, dashes, and underscores
+     * Validate that a field contains only valid username characters: alpha-numeric characters, dots, dashes, and underscores.
      *
-     * @param  string $field
-     * @param  mixed  $value
+     * @param string $field
+     * @param mixed  $value
+     *
      * @return bool
      */
     protected function validateUsername($field, $value)
@@ -177,7 +181,7 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
         call_user_func_array([$this, 'rule'], $params);
         // Set message.  Use Valitron's default message if not specified in the schema.
         if (!$messageSet) {
-            $messageSet = "'" . $params[1] . "' " . vsprintf(static::$_ruleMessages[$rule], array_slice(func_get_args(), 3));
+            $messageSet = "'".$params[1]."' ".vsprintf(static::$_ruleMessages[$rule], array_slice(func_get_args(), 3));
         }
         $this->message($messageSet);
     }
@@ -280,7 +284,7 @@ class ServerSideValidator extends Validator implements ServerSideValidatorInterf
                 }
                 // Regex validator
                 if ($validatorName == 'regex') {
-                    $this->ruleWithMessage('regex', $messageSet, $fieldName, '/' . $validator['regex'] . '/');
+                    $this->ruleWithMessage('regex', $messageSet, $fieldName, '/'.$validator['regex'].'/');
                 }
                 // Required validator
                 if ($validatorName == 'required') {

--- a/src/ServerSideValidatorInterface.php
+++ b/src/ServerSideValidatorInterface.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * UserFrosting Fortress (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/fortress

--- a/src/ServerSideValidatorInterface.php
+++ b/src/ServerSideValidatorInterface.php
@@ -14,7 +14,7 @@ use UserFrosting\Fortress\RequestSchema\RequestSchemaInterface;
 use UserFrosting\I18n\MessageTranslator;
 
 /**
- * ServerSideValidator Interface
+ * ServerSideValidator Interface.
  *
  * Loads validation rules from a schema and validates a target array of data.
  *
@@ -39,20 +39,21 @@ interface ServerSideValidatorInterface
     /**
      * Validate the specified data against the schema rules.
      *
-     * @param  array $data An array of data, mapping field names to field values.
-     * @return bool  True if the data was successfully validated, false otherwise.
+     * @param array $data An array of data, mapping field names to field values.
+     *
+     * @return bool True if the data was successfully validated, false otherwise.
      */
     public function validate(array $data);
 
     /**
-     *  Get array of fields and data
+     *  Get array of fields and data.
      *
      * @return array
      */
     public function data();
 
     /**
-     * Get array of error messages
+     * Get array of error messages.
      *
      * @return array|bool
      */

--- a/tests/ExtendSchemaTest.php
+++ b/tests/ExtendSchemaTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\UniformResourceLocator\ResourceLocator;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
@@ -39,37 +47,37 @@ class ExtendSchemaTest extends TestCase
 
         // Assert
         $this->assertEquals([
-            "name" => [
-                "validators" => [
-                    "length" => [
-                        "min" => 1,
-                        "max" => 200,
-                        "message" => "Please enter a name between 1 and 200 characters."
+            'name' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 1,
+                        'max'     => 200,
+                        'message' => 'Please enter a name between 1 and 200 characters.'
                     ],
-                    "required" => [
-                        "message" => "Please specify your name."
+                    'required' => [
+                        'message' => 'Please specify your name.'
                     ]
                 ]
             ],
-            "email" => [
-                "validators" => [
-                    "length" => [
-                        "min" => 1,
-                        "max" => 150,
-                        "message" => "Please enter an email address between 1 and 150 characters."
+            'email' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 1,
+                        'max'     => 150,
+                        'message' => 'Please enter an email address between 1 and 150 characters.'
                     ],
-                    "email" => [
-                        "message" => "That does not appear to be a valid email address."
+                    'email' => [
+                        'message' => 'That does not appear to be a valid email address.'
                     ],
-                    "required" => [
-                        "message" => "Please specify your email address."
+                    'required' => [
+                        'message' => 'Please specify your email address.'
                     ]
                 ]
             ],
-            "message" => [
-                "validators" => [
-                    "required" => [
-                        "message" => "Please enter a message"
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message'
                     ]
                 ]
             ]

--- a/tests/ExtendSchemaTest.php
+++ b/tests/ExtendSchemaTest.php
@@ -11,10 +11,10 @@
 namespace UserFrosting\Fortress\Tests;
 
 use PHPUnit\Framework\TestCase;
-use UserFrosting\UniformResourceLocator\ResourceLocator;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Support\Repository\Loader\YamlFileLoader;
 use UserFrosting\Support\Repository\PathBuilder\StreamPathBuilder;
+use UserFrosting\UniformResourceLocator\ResourceLocator;
 
 class ExtendSchemaTest extends TestCase
 {
@@ -24,7 +24,7 @@ class ExtendSchemaTest extends TestCase
 
     public function setUp()
     {
-        $this->basePath = __DIR__ . '/data';
+        $this->basePath = __DIR__.'/data';
 
         // Arrange
         $this->locator = new ResourceLocator($this->basePath);
@@ -54,35 +54,35 @@ class ExtendSchemaTest extends TestCase
                     'length' => [
                         'min'     => 1,
                         'max'     => 200,
-                        'message' => 'Please enter a name between 1 and 200 characters.'
+                        'message' => 'Please enter a name between 1 and 200 characters.',
                     ],
                     'required' => [
-                        'message' => 'Please specify your name.'
-                    ]
-                ]
+                        'message' => 'Please specify your name.',
+                    ],
+                ],
             ],
             'email' => [
                 'validators' => [
                     'length' => [
                         'min'     => 1,
                         'max'     => 150,
-                        'message' => 'Please enter an email address between 1 and 150 characters.'
+                        'message' => 'Please enter an email address between 1 and 150 characters.',
                     ],
                     'email' => [
-                        'message' => 'That does not appear to be a valid email address.'
+                        'message' => 'That does not appear to be a valid email address.',
                     ],
                     'required' => [
-                        'message' => 'Please specify your email address.'
-                    ]
-                ]
+                        'message' => 'Please specify your email address.',
+                    ],
+                ],
             ],
             'message' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please enter a message'
-                    ]
-                ]
-            ]
+                        'message' => 'Please enter a message',
+                    ],
+                ],
+            ],
         ], $result);
     }
 }

--- a/tests/ExtendSchemaTest.php
+++ b/tests/ExtendSchemaTest.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
  */
 
+namespace UserFrosting\Fortress\Tests;
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\UniformResourceLocator\ResourceLocator;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;

--- a/tests/FormValidationAdapterTest.php
+++ b/tests/FormValidationAdapterTest.php
@@ -67,7 +67,7 @@ class FormValidationAdapterTest extends TestCase
 
     /**
      * N.B.: equals is not a supported validator in FormValidationAdapter.
-     * Let's test what's happening when this happens
+     * Let's test what's happening when this happens.
      */
     public function testValidateEquals()
     {
@@ -513,8 +513,8 @@ class FormValidationAdapterTest extends TestCase
         // Test with html5 format
         $result = $adapter->rules('html5');
         $expectedResult = [
-            'password' => 'data-fv-identical=true data-fv-identical-message="The value of this field does not match the value of the \'{{field}}\' field." ',
-            'passwordc' => 'data-fv-identical=true data-fv-identical-message="The value of this field does not match the value of the \'{{field}}\' field." data-fv-identical-field=password '
+            'password'  => 'data-fv-identical=true data-fv-identical-message="The value of this field does not match the value of the \'{{field}}\' field." ',
+            'passwordc' => 'data-fv-identical=true data-fv-identical-message="The value of this field does not match the value of the \'{{field}}\' field." data-fv-identical-field=password ',
         ];
         $this->assertEquals($expectedResult, $result);
     }

--- a/tests/FormValidationAdapterTest.php
+++ b/tests/FormValidationAdapterTest.php
@@ -490,6 +490,9 @@ class FormValidationAdapterTest extends TestCase
                     ],
                 ],
             ],
+            'passwordc' => [
+                'validators' => [],
+            ],
         ]);
 
         $expectedResult = [
@@ -501,6 +504,9 @@ class FormValidationAdapterTest extends TestCase
                     ],
                 ],
             ],
+            'passwordc' => [
+                'validators' => [],
+            ],
         ];
 
         // Act
@@ -508,7 +514,7 @@ class FormValidationAdapterTest extends TestCase
         $result = $adapter->rules();
 
         // Assert
-        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT), $result);
 
         // Test with html5 format
         $result = $adapter->rules('html5');

--- a/tests/FormValidationAdapterTest.php
+++ b/tests/FormValidationAdapterTest.php
@@ -1,0 +1,678 @@
+<?php
+
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace UserFrosting\Fortress\Tests;
+
+use PHPUnit\Framework\TestCase;
+use UserFrosting\Fortress\Adapter\FormValidationAdapter;
+use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
+use UserFrosting\I18n\MessageTranslator;
+
+class FormValidationAdapterTest extends TestCase
+{
+    protected $translator;
+
+    public function setUp()
+    {
+        // Create a message translator
+        $this->translator = new MessageTranslator();
+    }
+
+    public function testValidateEmail()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'email' => [
+                'validators' => [
+                    'email' => [
+                        'message' => 'Not a valid email address...we think.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'email' => [
+                'validators' => [
+                    'emailAddress' => [
+                        'message' => 'Not a valid email address...we think.',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with stringEncode as true
+        $result = $adapter->rules('json', false);
+        $this->assertEquals($expectedResult, $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['email' => 'data-fv-emailaddress=true data-fv-emailaddress-message="Not a valid email address...we think." '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * N.B.: equals is not a supported validator in FormValidationAdapter.
+     * Let's test what's happening when this happens
+     */
+    public function testValidateEquals()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'voles' => [
+                'validators' => [
+                    'equals' => [
+                        'value'         => 8,
+                        'caseSensitive' => false,
+                        'message'       => 'Voles must be equal to {{value}}.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'voles' => [
+                'validators' => [
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['voles' => ''];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateRequired()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'species' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please tell us your species.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'species' => [
+                'validators' => [
+                    'notEmpty' => [
+                        'message' => 'Please tell us your species.',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['species' => 'data-fv-notempty=true data-fv-notempty-message="Please tell us your species." '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateLengthBetween()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'screech' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'screech' => [
+                'validators' => [
+                    'stringLength' => [
+                        'message' => 'Your screech must be between 5 and 10 characters long.',
+                        'min'     => 5,
+                        'max'     => 10,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['screech' => 'data-fv-stringlength=true data-fv-stringlength-message="Your screech must be between {{min}} and {{max}} characters long." data-fv-stringlength-min=5 data-fv-stringlength-max=10 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateLengthMin()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'screech' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 5,
+                        'message' => 'Your screech must be at least {{min}} characters long.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'screech' => [
+                'validators' => [
+                    'stringLength' => [
+                        'message' => 'Your screech must be at least 5 characters long.',
+                        'min'     => 5,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['screech' => 'data-fv-stringlength=true data-fv-stringlength-message="Your screech must be at least {{min}} characters long." data-fv-stringlength-min=5 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateLengthMax()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'screech' => [
+                'validators' => [
+                    'length' => [
+                        'max'     => 10,
+                        'message' => 'Your screech must be no more than {{max}} characters long.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'screech' => [
+                'validators' => [
+                    'stringLength' => [
+                        'message' => 'Your screech must be no more than 10 characters long.',
+                        'max'     => 10,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['screech' => 'data-fv-stringlength=true data-fv-stringlength-message="Your screech must be no more than {{max}} characters long." data-fv-stringlength-max=10 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateInteger()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'voles' => [
+                'validators' => [
+                    'integer' => [
+                        'message' => 'Voles must be numeric.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'voles' => [
+                'validators' => [
+                    'integer' => [
+                        'message' => 'Voles must be numeric.',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['voles' => 'data-fv-integer=true data-fv-integer-message="Voles must be numeric." '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateNumeric()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'accuracy' => [
+                'validators' => [
+                    'numeric' => [
+                        'message' => 'Sorry, your strike accuracy must be a number.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'accuracy' => [
+                'validators' => [
+                    'numeric' => [
+                        'message' => 'Sorry, your strike accuracy must be a number.',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+    }
+
+    public function testValidateRange()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'voles' => [
+                'validators' => [
+                    'range' => [
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'You must catch {{min}} - {{max}} voles.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'voles' => [
+                'validators' => [
+                    'between' => [
+                        'message' => 'You must catch 5 - 10 voles.',
+                        'min'     => 5,
+                        'max'     => 10,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['voles' => 'data-fv-between=true data-fv-between-message="You must catch {{min}} - {{max}} voles." data-fv-between-min=5 data-fv-between-max=10 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateRangeMin()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'voles' => [
+                'validators' => [
+                    'range' => [
+                        'min'     => 5,
+                        'message' => 'You must catch at least {{min}} voles.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'voles' => [
+                'validators' => [
+                    'greaterThan' => [
+                        'message' => 'You must catch at least 5 voles.',
+                        'min'     => 5,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['voles' => 'data-fv-greaterthan=true data-fv-greaterthan-message="You must catch at least {{min}} voles." data-fv-greaterthan-value=5 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateRangeMax()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'voles' => [
+                'validators' => [
+                    'range' => [
+                        'max'     => 10,
+                        'message' => 'You must catch no more than {{max}} voles.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'voles' => [
+                'validators' => [
+                    'lessThan' => [
+                        'message' => 'You must catch no more than 10 voles.',
+                        'max'     => 10,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['voles' => 'data-fv-lessthan=true data-fv-lessthan-message="You must catch no more than {{max}} voles." data-fv-lessthan-value=10 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateArray()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'voles' => [
+                'validators' => [
+                    'array' => [
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'You must choose between {{min}} and {{max}} voles.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'voles' => [
+                'validators' => [
+                    'choice' => [
+                        'message' => 'You must choose between 5 and 10 voles.',
+                        'min'     => 5,
+                        'max'     => 10,
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['voles' => 'data-fv-choice=true data-fv-choice-message="You must choose between {{min}} and {{max}} voles." data-fv-choice-min=5 data-fv-choice-max=10 '];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateMatches()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'password' => [
+                'validators' => [
+                    'matches' => [
+                        'field'   => 'passwordc',
+                        'message' => "The value of this field does not match the value of the '{{field}}' field.",
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'password' => [
+                'validators' => [
+                    'identical' => [
+                        'message' => "The value of this field does not match the value of the 'passwordc' field.",
+                        'field'   => 'passwordc',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = [
+            'password' => 'data-fv-identical=true data-fv-identical-message="The value of this field does not match the value of the \'{{field}}\' field." ',
+            'passwordc' => 'data-fv-identical=true data-fv-identical-message="The value of this field does not match the value of the \'{{field}}\' field." data-fv-identical-field=password '
+        ];
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testValidateMatchesNoFields()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'password' => [
+                'validators' => [
+                    'matches' => [
+                        'message' => "The value of this field does not match the value of the '{{field}}' field.",
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'password' => [
+                'validators' => [
+                    'identical' => [
+                        'message' => "The value of this field does not match the value of the '' field.",
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $this->assertEquals(null, $result);
+    }
+
+    public function testValidateNotMatches()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'password' => [
+                'validators' => [
+                    'not_matches' => [
+                        'field'   => 'user_name',
+                        'message' => 'Your password cannot be the same as your username.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'password' => [
+                'validators' => [
+                    'different' => [
+                        'message' => 'Your password cannot be the same as your username.',
+                        'field'   => 'user_name',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+    }
+
+    public function testValidateMemberOf()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'genus' => [
+                'validators' => [
+                    'member_of' => [
+                        'values'  => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene'],
+                        'message' => 'Sorry, that is not one of the permitted genuses.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'genus' => [
+                'validators' => [
+                    'regexp' => [
+                        'message' => 'Sorry, that is not one of the permitted genuses.',
+                        'regexp'  => '^Megascops|Bubo|Glaucidium|Tyto|Athene$',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+    }
+
+    public function testValidateNotMemberOf()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'genus' => [
+                'validators' => [
+                    'not_member_of' => [
+                        'values'  => ['Myodes', 'Microtus', 'Neodon', 'Alticola'],
+                        'message' => 'Sorry, it would appear that you are not an owl.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expectedResult = [
+            'genus' => [
+                'validators' => [
+                    'regexp' => [
+                        'message' => 'Sorry, it would appear that you are not an owl.',
+                        'regexp'  => '^(?!Myodes|Microtus|Neodon|Alticola$).*$',
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        // Assert
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
+    }
+
+    public function testDomainRulesServerOnly()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'plumage' => [
+                'validators' => [
+                    'required' => [
+                        'domain'  => 'server',
+                        'message' => "Are you sure you don't want to show us your plumage?",
+                    ],
+                ],
+            ],
+        ]);
+
+        // Act
+        $adapter = new FormValidationAdapter($schema, $this->translator);
+
+        // Test with html5 format
+        $result = $adapter->rules('html5');
+        $expectedResult = ['plumage' => ''];
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/JqueryValidationAdapterTest.php
+++ b/tests/JqueryValidationAdapterTest.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
  */
 
+namespace UserFrosting\Fortress\Tests;
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\Adapter\JqueryValidationAdapter;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;

--- a/tests/JqueryValidationAdapterTest.php
+++ b/tests/JqueryValidationAdapterTest.php
@@ -38,11 +38,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
         ]);
 
-        // Act
-        $adapter = new JqueryValidationAdapter($schema, $this->translator);
-        $result = $adapter->rules();
-
-        $this->assertEquals([
+        $expectedResult = [
             'rules' => [
                 'email' => [
                     'email' => true,
@@ -53,7 +49,17 @@ class JqueryValidationAdapterTest extends TestCase
                     'email' => 'Not a valid email address...we think.',
                 ],
             ],
-        ], $result);
+        ];
+
+        // Act
+        $adapter = new JqueryValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        $this->assertEquals($expectedResult, $result);
+
+        // Test with stringEncode as true
+        $result = $adapter->rules('json', true);
+        $this->assertEquals(json_encode($expectedResult, JSON_PRETTY_PRINT), $result);
     }
 
     public function testValidateEquals()
@@ -764,7 +770,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
         ], $result);
 
-        // Srinvas Nukala : Adding Test with Form array prefix 'coolform1'
+        // Adding Test with Form array prefix 'coolform1'
         $result1 = $adapter->rules('json', false, 'coolform1');
 
         $this->assertEquals([
@@ -806,7 +812,7 @@ class JqueryValidationAdapterTest extends TestCase
             'messages' => [],
         ], $result);
 
-        // Srinvas Nukala : Adding Test with Form array prefix 'coolform1'
+        // Adding Test with Form array prefix 'coolform1'
         $result1 = $adapter->rules('json', false, 'coolform1');
 
         $this->assertEquals([
@@ -1037,7 +1043,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
         ], $result);
 
-        // Srinvas Nukala : Adding Test with Form array prefix 'coolform1'
+        // Adding Test with Form array prefix 'coolform1'
         $result1 = $adapter->rules('json', false, 'coolform1');
 
         $this->assertEquals([
@@ -1136,5 +1142,32 @@ class JqueryValidationAdapterTest extends TestCase
                 ],
             ],
         ], $result1);
+    }
+
+    public function testValidateNoRule()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'user_name' => [
+                'validators' => [
+                    'foo' => [
+                        'message' => "Sorry buddy, that's not a valid username.",
+                    ],
+                ],
+            ],
+        ]);
+
+        // Act
+        $adapter = new JqueryValidationAdapter($schema, $this->translator);
+        $result = $adapter->rules();
+
+        $this->assertEquals([
+            'rules' => [
+                'user_name' => [],
+            ],
+            'messages' => [
+                'user_name' => [],
+            ],
+        ], $result);
     }
 }

--- a/tests/JqueryValidationAdapterTest.php
+++ b/tests/JqueryValidationAdapterTest.php
@@ -32,10 +32,10 @@ class JqueryValidationAdapterTest extends TestCase
             'email' => [
                 'validators' => [
                     'email' => [
-                        'message' => 'Not a valid email address...we think.'
-                    ]
-                ]
-            ]
+                        'message' => 'Not a valid email address...we think.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -45,14 +45,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'email' => [
-                    'email' => true
-                ]
+                    'email' => true,
+                ],
             ],
             'messages' => [
                 'email' => [
-                    'email' => 'Not a valid email address...we think.'
-                ]
-            ]
+                    'email' => 'Not a valid email address...we think.',
+                ],
+            ],
         ], $result);
     }
 
@@ -65,10 +65,10 @@ class JqueryValidationAdapterTest extends TestCase
                     'equals' => [
                         'value'         => 8,
                         'caseSensitive' => false,
-                        'message'       => 'Voles must be equal to {{value}}.'
-                    ]
-                ]
-            ]
+                        'message'       => 'Voles must be equal to {{value}}.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -81,15 +81,15 @@ class JqueryValidationAdapterTest extends TestCase
                     'equals' => [
                         'value'         => 8,
                         'caseSensitive' => false,
-                        'message'       => 'Voles must be equal to {{value}}.'
-                    ]
-                ]
+                        'message'       => 'Voles must be equal to {{value}}.',
+                    ],
+                ],
             ],
             'messages' => [
                 'voles' => [
-                    'equals' => 'Voles must be equal to 8.'
-                ]
-            ]
+                    'equals' => 'Voles must be equal to 8.',
+                ],
+            ],
         ], $result);
     }
 
@@ -100,10 +100,10 @@ class JqueryValidationAdapterTest extends TestCase
             'voles' => [
                 'validators' => [
                     'integer' => [
-                        'message' => 'Voles must be numeric.'
-                    ]
-                ]
-            ]
+                        'message' => 'Voles must be numeric.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -113,14 +113,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'voles' => [
-                    'digits' => true
-                ]
+                    'digits' => true,
+                ],
             ],
             'messages' => [
                 'voles' => [
-                    'digits' => 'Voles must be numeric.'
-                ]
-            ]
+                    'digits' => 'Voles must be numeric.',
+                ],
+            ],
         ], $result);
     }
 
@@ -133,10 +133,10 @@ class JqueryValidationAdapterTest extends TestCase
                     'length' => [
                         'min'     => 5,
                         'max'     => 10,
-                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -146,14 +146,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'screech' => [
-                    'rangelength' => [5, 10]
-                ]
+                    'rangelength' => [5, 10],
+                ],
             ],
             'messages' => [
                 'screech' => [
-                    'rangelength' => 'Your screech must be between 5 and 10 characters long.'
-                ]
-            ]
+                    'rangelength' => 'Your screech must be between 5 and 10 characters long.',
+                ],
+            ],
         ], $result);
     }
 
@@ -165,10 +165,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'length' => [
                         'min'     => 5,
-                        'message' => 'Your screech must be at least {{min}} characters long.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your screech must be at least {{min}} characters long.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -178,14 +178,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'screech' => [
-                    'minlength' => 5
-                ]
+                    'minlength' => 5,
+                ],
             ],
             'messages' => [
                 'screech' => [
-                    'minlength' => 'Your screech must be at least 5 characters long.'
-                ]
-            ]
+                    'minlength' => 'Your screech must be at least 5 characters long.',
+                ],
+            ],
         ], $result);
     }
 
@@ -197,10 +197,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'length' => [
                         'max'     => 10,
-                        'message' => 'Your screech must be no more than {{max}} characters long.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your screech must be no more than {{max}} characters long.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -210,14 +210,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'screech' => [
-                    'maxlength' => 10
-                ]
+                    'maxlength' => 10,
+                ],
             ],
             'messages' => [
                 'screech' => [
-                    'maxlength' => 'Your screech must be no more than 10 characters long.'
-                ]
-            ]
+                    'maxlength' => 'Your screech must be no more than 10 characters long.',
+                ],
+            ],
         ], $result);
     }
 
@@ -229,10 +229,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'matches' => [
                         'field'   => 'passwordc',
-                        'message' => "The value of this field does not match the value of the '{{field}}' field."
-                    ]
-                ]
-            ]
+                        'message' => "The value of this field does not match the value of the '{{field}}' field.",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -242,14 +242,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'password' => [
-                    'matchFormField' => 'passwordc'
-                ]
+                    'matchFormField' => 'passwordc',
+                ],
             ],
             'messages' => [
                 'password' => [
-                    'matchFormField' => "The value of this field does not match the value of the 'passwordc' field."
-                ]
-            ]
+                    'matchFormField' => "The value of this field does not match the value of the 'passwordc' field.",
+                ],
+            ],
         ], $result);
     }
 
@@ -261,10 +261,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'member_of' => [
                         'values'  => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene'],
-                        'message' => 'Sorry, that is not one of the permitted genuses.'
-                    ]
-                ]
-            ]
+                        'message' => 'Sorry, that is not one of the permitted genuses.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -274,14 +274,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'genus' => [
-                    'memberOf' => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene']
-                ]
+                    'memberOf' => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene'],
+                ],
             ],
             'messages' => [
                 'genus' => [
-                    'memberOf' => 'Sorry, that is not one of the permitted genuses.'
-                ]
-            ]
+                    'memberOf' => 'Sorry, that is not one of the permitted genuses.',
+                ],
+            ],
         ], $result);
     }
 
@@ -292,10 +292,10 @@ class JqueryValidationAdapterTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'no_leading_whitespace' => [
-                        'message' => "'{{self}}' cannot begin with whitespace characters"
-                    ]
-                ]
-            ]
+                        'message' => "'{{self}}' cannot begin with whitespace characters",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -305,14 +305,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'user_name' => [
-                    'noLeadingWhitespace' => true
-                ]
+                    'noLeadingWhitespace' => true,
+                ],
             ],
             'messages' => [
                 'user_name' => [
-                    'noLeadingWhitespace' => "'user_name' cannot begin with whitespace characters"
-                ]
-            ]
+                    'noLeadingWhitespace' => "'user_name' cannot begin with whitespace characters",
+                ],
+            ],
         ], $result);
     }
 
@@ -323,10 +323,10 @@ class JqueryValidationAdapterTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'no_trailing_whitespace' => [
-                        'message' => "'{{self}}' cannot end with whitespace characters"
-                    ]
-                ]
-            ]
+                        'message' => "'{{self}}' cannot end with whitespace characters",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -336,14 +336,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'user_name' => [
-                    'noTrailingWhitespace' => true
-                ]
+                    'noTrailingWhitespace' => true,
+                ],
             ],
             'messages' => [
                 'user_name' => [
-                    'noTrailingWhitespace' => "'user_name' cannot end with whitespace characters"
-                ]
-            ]
+                    'noTrailingWhitespace' => "'user_name' cannot end with whitespace characters",
+                ],
+            ],
         ], $result);
     }
 
@@ -357,10 +357,10 @@ class JqueryValidationAdapterTest extends TestCase
                     'not_equals' => [
                         'value'         => 0,
                         'caseSensitive' => false,
-                        'message'       => 'Voles must not be equal to {{value}}.'
-                    ]
-                ]
-            ]
+                        'message'       => 'Voles must not be equal to {{value}}.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -373,15 +373,15 @@ class JqueryValidationAdapterTest extends TestCase
                     'notEquals' => [
                         'value'         => 0,
                         'caseSensitive' => false,
-                        'message'       => 'Voles must not be equal to {{value}}.'
-                    ]
-                ]
+                        'message'       => 'Voles must not be equal to {{value}}.',
+                    ],
+                ],
             ],
             'messages' => [
                 'voles' => [
-                    'notEquals' => 'Voles must not be equal to 0.'
-                ]
-            ]
+                    'notEquals' => 'Voles must not be equal to 0.',
+                ],
+            ],
         ], $result);
     }
 
@@ -393,10 +393,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'not_matches' => [
                         'field'   => 'user_name',
-                        'message' => 'Your password cannot be the same as your username.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your password cannot be the same as your username.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -406,14 +406,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'password' => [
-                    'notMatchFormField' => 'user_name'
-                ]
+                    'notMatchFormField' => 'user_name',
+                ],
             ],
             'messages' => [
                 'password' => [
-                    'notMatchFormField' => 'Your password cannot be the same as your username.'
-                ]
-            ]
+                    'notMatchFormField' => 'Your password cannot be the same as your username.',
+                ],
+            ],
         ], $result);
     }
 
@@ -425,10 +425,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'not_member_of' => [
                         'values'  => ['Myodes', 'Microtus', 'Neodon', 'Alticola'],
-                        'message' => 'Sorry, it would appear that you are not an owl.'
-                    ]
-                ]
-            ]
+                        'message' => 'Sorry, it would appear that you are not an owl.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -438,14 +438,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'genus' => [
-                    'notMemberOf' => ['Myodes', 'Microtus', 'Neodon', 'Alticola']
-                ]
+                    'notMemberOf' => ['Myodes', 'Microtus', 'Neodon', 'Alticola'],
+                ],
             ],
             'messages' => [
                 'genus' => [
-                    'notMemberOf' => 'Sorry, it would appear that you are not an owl.'
-                ]
-            ]
+                    'notMemberOf' => 'Sorry, it would appear that you are not an owl.',
+                ],
+            ],
         ], $result);
     }
 
@@ -456,10 +456,10 @@ class JqueryValidationAdapterTest extends TestCase
             'accuracy' => [
                 'validators' => [
                     'numeric' => [
-                        'message' => 'Sorry, your strike accuracy must be a number.'
-                    ]
-                ]
-            ]
+                        'message' => 'Sorry, your strike accuracy must be a number.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -469,14 +469,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'accuracy' => [
-                    'number' => true
-                ]
+                    'number' => true,
+                ],
             ],
             'messages' => [
                 'accuracy' => [
-                    'number' => 'Sorry, your strike accuracy must be a number.'
-                ]
-            ]
+                    'number' => 'Sorry, your strike accuracy must be a number.',
+                ],
+            ],
         ], $result);
     }
 
@@ -489,10 +489,10 @@ class JqueryValidationAdapterTest extends TestCase
                     'range' => [
                         'min'     => 5,
                         'max'     => 10,
-                        'message' => 'You must catch {{min}} - {{max}} voles.'
-                    ]
-                ]
-            ]
+                        'message' => 'You must catch {{min}} - {{max}} voles.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -502,14 +502,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'voles' => [
-                    'range' => [5, 10]
-                ]
+                    'range' => [5, 10],
+                ],
             ],
             'messages' => [
                 'voles' => [
-                    'range' => 'You must catch 5 - 10 voles.'
-                ]
-            ]
+                    'range' => 'You must catch 5 - 10 voles.',
+                ],
+            ],
         ], $result);
     }
 
@@ -521,10 +521,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'range' => [
                         'min'     => 5,
-                        'message' => 'You must catch at least {{min}} voles.'
-                    ]
-                ]
-            ]
+                        'message' => 'You must catch at least {{min}} voles.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -534,14 +534,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'voles' => [
-                    'min' => 5
-                ]
+                    'min' => 5,
+                ],
             ],
             'messages' => [
                 'voles' => [
-                    'min' => 'You must catch at least 5 voles.'
-                ]
-            ]
+                    'min' => 'You must catch at least 5 voles.',
+                ],
+            ],
         ], $result);
     }
 
@@ -553,10 +553,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'range' => [
                         'max'     => 10,
-                        'message' => 'You must catch no more than {{max}} voles.'
-                    ]
-                ]
-            ]
+                        'message' => 'You must catch no more than {{max}} voles.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -566,14 +566,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'voles' => [
-                    'max' => 10
-                ]
+                    'max' => 10,
+                ],
             ],
             'messages' => [
                 'voles' => [
-                    'max' => 'You must catch no more than 10 voles.'
-                ]
-            ]
+                    'max' => 'You must catch no more than 10 voles.',
+                ],
+            ],
         ], $result);
     }
 
@@ -585,10 +585,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'regex' => [
                         'regex'   => '^who(o*)$',
-                        'message' => 'You did not provide a valid screech.'
-                    ]
-                ]
-            ]
+                        'message' => 'You did not provide a valid screech.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -598,14 +598,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'screech' => [
-                    'pattern' => '^who(o*)$'
-                ]
+                    'pattern' => '^who(o*)$',
+                ],
             ],
             'messages' => [
                 'screech' => [
-                    'pattern' => 'You did not provide a valid screech.'
-                ]
-            ]
+                    'pattern' => 'You did not provide a valid screech.',
+                ],
+            ],
         ], $result);
     }
 
@@ -616,10 +616,10 @@ class JqueryValidationAdapterTest extends TestCase
             'species' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please tell us your species.'
-                    ]
-                ]
-            ]
+                        'message' => 'Please tell us your species.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -629,14 +629,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'species' => [
-                    'required' => true
-                ]
+                    'required' => true,
+                ],
             ],
             'messages' => [
                 'species' => [
-                    'required' => 'Please tell us your species.'
-                ]
-            ]
+                    'required' => 'Please tell us your species.',
+                ],
+            ],
         ], $result);
     }
 
@@ -647,10 +647,10 @@ class JqueryValidationAdapterTest extends TestCase
             'phone' => [
                 'validators' => [
                     'telephone' => [
-                        'message' => 'Whoa there, check your phone number again.'
-                    ]
-                ]
-            ]
+                        'message' => 'Whoa there, check your phone number again.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -660,14 +660,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'phone' => [
-                    'phoneUS' => true
-                ]
+                    'phoneUS' => true,
+                ],
             ],
             'messages' => [
                 'phone' => [
-                    'phoneUS' => 'Whoa there, check your phone number again.'
-                ]
-            ]
+                    'phoneUS' => 'Whoa there, check your phone number again.',
+                ],
+            ],
         ], $result);
     }
 
@@ -678,10 +678,10 @@ class JqueryValidationAdapterTest extends TestCase
             'website' => [
                 'validators' => [
                     'uri' => [
-                        'message' => "That's not even a valid URL..."
-                    ]
-                ]
-            ]
+                        'message' => "That's not even a valid URL...",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -691,14 +691,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'website' => [
-                    'url' => true
-                ]
+                    'url' => true,
+                ],
             ],
             'messages' => [
                 'website' => [
-                    'url' => "That's not even a valid URL..."
-                ]
-            ]
+                    'url' => "That's not even a valid URL...",
+                ],
+            ],
         ], $result);
     }
 
@@ -709,10 +709,10 @@ class JqueryValidationAdapterTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'username' => [
-                        'message' => "Sorry buddy, that's not a valid username."
-                    ]
-                ]
-            ]
+                        'message' => "Sorry buddy, that's not a valid username.",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -722,14 +722,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'user_name' => [
-                    'username' => true
-                ]
+                    'username' => true,
+                ],
             ],
             'messages' => [
                 'user_name' => [
-                    'username' => "Sorry buddy, that's not a valid username."
-                ]
-            ]
+                    'username' => "Sorry buddy, that's not a valid username.",
+                ],
+            ],
         ], $result);
     }
 
@@ -741,10 +741,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'required' => [
                         'domain'  => 'client',
-                        'message' => "Are you sure you don't want to show us your plumage?"
-                    ]
-                ]
-            ]
+                        'message' => "Are you sure you don't want to show us your plumage?",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -754,14 +754,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'plumage' => [
-                    'required' => true
-                ]
+                    'required' => true,
+                ],
             ],
             'messages' => [
                 'plumage' => [
-                    'required' => "Are you sure you don't want to show us your plumage?"
-                ]
-            ]
+                    'required' => "Are you sure you don't want to show us your plumage?",
+                ],
+            ],
         ], $result);
 
         // Srinvas Nukala : Adding Test with Form array prefix 'coolform1'
@@ -770,14 +770,14 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'coolform1[plumage]' => [
-                    'required' => true
-                ]
+                    'required' => true,
+                ],
             ],
             'messages' => [
                 'coolform1[plumage]' => [
-                    'required' => "Are you sure you don't want to show us your plumage?"
-                ]
-            ]
+                    'required' => "Are you sure you don't want to show us your plumage?",
+                ],
+            ],
         ], $result1);
     }
 
@@ -789,10 +789,10 @@ class JqueryValidationAdapterTest extends TestCase
                 'validators' => [
                     'required' => [
                         'domain'  => 'server',
-                        'message' => "Are you sure you don't want to show us your plumage?"
-                    ]
-                ]
-            ]
+                        'message' => "Are you sure you don't want to show us your plumage?",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -801,9 +801,9 @@ class JqueryValidationAdapterTest extends TestCase
 
         $this->assertEquals([
             'rules' => [
-                'plumage' => []
+                'plumage' => [],
             ],
-            'messages' => []
+            'messages' => [],
         ], $result);
 
         // Srinvas Nukala : Adding Test with Form array prefix 'coolform1'
@@ -811,9 +811,9 @@ class JqueryValidationAdapterTest extends TestCase
 
         $this->assertEquals([
             'rules' => [
-                'coolform1[plumage]' => []
+                'coolform1[plumage]' => [],
             ],
-            'messages' => []
+            'messages' => [],
         ], $result1);
     }
 
@@ -894,46 +894,46 @@ class JqueryValidationAdapterTest extends TestCase
             'email' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'ACCOUNT_SPECIFY_EMAIL'
+                        'message' => 'ACCOUNT_SPECIFY_EMAIL',
                     ],
                     'length' => [
                         'min'     => 1,
                         'max'     => 100,
-                        'message' => 'ACCOUNT_EMAIL_CHAR_LIMIT'
+                        'message' => 'ACCOUNT_EMAIL_CHAR_LIMIT',
                     ],
                     'email' => [
-                        'message' => 'ACCOUNT_INVALID_EMAIL'
+                        'message' => 'ACCOUNT_INVALID_EMAIL',
                     ],
-                ]
+                ],
             ],
             'password' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'ACCOUNT_SPECIFY_PASSWORD'
+                        'message' => 'ACCOUNT_SPECIFY_PASSWORD',
                     ],
                     'length' => [
                         'min'     => 8,
                         'max'     => 50,
-                        'message' => 'ACCOUNT_PASS_CHAR_LIMIT'
+                        'message' => 'ACCOUNT_PASS_CHAR_LIMIT',
                     ],
                 ],
             ],
             'passwordc' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'ACCOUNT_SPECIFY_PASSWORD'
+                        'message' => 'ACCOUNT_SPECIFY_PASSWORD',
                     ],
                     'matches' => [
                         'field'   => 'password',
-                        'message' => 'ACCOUNT_PASS_MISMATCH'
+                        'message' => 'ACCOUNT_PASS_MISMATCH',
                     ],
                     'length' => [
                         'min'     => 8,
                         'max'     => 50,
-                        'message' => 'ACCOUNT_PASS_CHAR_LIMIT'
-                    ]
-                ]
-            ]
+                        'message' => 'ACCOUNT_PASS_CHAR_LIMIT',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -945,59 +945,59 @@ class JqueryValidationAdapterTest extends TestCase
                 'user_name' => [
                     'rangelength' => [
                         0 => 1,
-                        1 => 50
+                        1 => 50,
                     ],
                     'noLeadingWhitespace'  => true,
                     'noTrailingWhitespace' => true,
                     'required'             => true,
-                    'username'             => true
+                    'username'             => true,
                 ],
                 'display_name' => [
                     'rangelength' => [
                         0 => 1,
                         1 => 50,
                     ],
-                    'required' => true
+                    'required' => true,
                 ],
                 'secret' => [
                     'rangelength' => [
                         0 => 1,
-                        1 => 100
+                        1 => 100,
                     ],
-                    'number' => true
+                    'number' => true,
                 ],
                 'puppies' => [
                     'memberOf' => [
                         0 => '0',
-                        1 => '1'
-                    ]
+                        1 => '1',
+                    ],
                 ],
                 'phone' => [
-                    'phoneUS' => true
+                    'phoneUS' => true,
                 ],
                 'email' => [
                     'required'    => true,
                     'rangelength' => [
                         0 => 1,
-                        1 => 100
+                        1 => 100,
                     ],
-                    'email' => true
+                    'email' => true,
                 ],
                 'password' => [
                     'required'    => true,
                     'rangelength' => [
                         0 => 8,
-                        1 => 50
-                    ]
+                        1 => 50,
+                    ],
                 ],
                 'passwordc' => [
                     'required'       => true,
                     'matchFormField' => 'password',
                     'rangelength'    => [
                         0 => 8,
-                        1 => 50
-                    ]
-                ]
+                        1 => 50,
+                    ],
+                ],
             ],
             'messages' => [
                 'user_name' => [
@@ -1032,8 +1032,8 @@ class JqueryValidationAdapterTest extends TestCase
                 'passwordc' => [
                     'required'       => 'ACCOUNT_SPECIFY_PASSWORD',
                     'matchFormField' => 'ACCOUNT_PASS_MISMATCH',
-                    'rangelength'    => 'ACCOUNT_PASS_CHAR_LIMIT'
-                ]
+                    'rangelength'    => 'ACCOUNT_PASS_CHAR_LIMIT',
+                ],
             ],
         ], $result);
 
@@ -1045,59 +1045,59 @@ class JqueryValidationAdapterTest extends TestCase
                 'coolform1[user_name]' => [
                     'rangelength' => [
                         0 => 1,
-                        1 => 50
+                        1 => 50,
                     ],
                     'noLeadingWhitespace'  => true,
                     'noTrailingWhitespace' => true,
                     'required'             => true,
-                    'username'             => true
+                    'username'             => true,
                 ],
                 'coolform1[display_name]' => [
                     'rangelength' => [
                         0 => 1,
                         1 => 50,
                     ],
-                    'required' => true
+                    'required' => true,
                 ],
                 'coolform1[secret]' => [
                     'rangelength' => [
                         0 => 1,
-                        1 => 100
+                        1 => 100,
                     ],
-                    'number' => true
+                    'number' => true,
                 ],
                 'coolform1[puppies]' => [
                     'memberOf' => [
                         0 => '0',
-                        1 => '1'
-                    ]
+                        1 => '1',
+                    ],
                 ],
                 'coolform1[phone]' => [
-                    'phoneUS' => true
+                    'phoneUS' => true,
                 ],
                 'coolform1[email]' => [
                     'required'    => true,
                     'rangelength' => [
                         0 => 1,
-                        1 => 100
+                        1 => 100,
                     ],
-                    'email' => true
+                    'email' => true,
                 ],
                 'coolform1[password]' => [
                     'required'    => true,
                     'rangelength' => [
                         0 => 8,
-                        1 => 50
-                    ]
+                        1 => 50,
+                    ],
                 ],
                 'coolform1[passwordc]' => [
                     'required'       => true,
                     'matchFormField' => 'password',
                     'rangelength'    => [
                         0 => 8,
-                        1 => 50
-                    ]
-                ]
+                        1 => 50,
+                    ],
+                ],
             ],
             'messages' => [
                 'coolform1[user_name]' => [
@@ -1132,8 +1132,8 @@ class JqueryValidationAdapterTest extends TestCase
                 'coolform1[passwordc]' => [
                     'required'       => 'ACCOUNT_SPECIFY_PASSWORD',
                     'matchFormField' => 'ACCOUNT_PASS_MISMATCH',
-                    'rangelength'    => 'ACCOUNT_PASS_CHAR_LIMIT'
-                ]
+                    'rangelength'    => 'ACCOUNT_PASS_CHAR_LIMIT',
+                ],
             ],
         ], $result1);
     }

--- a/tests/JqueryValidationAdapterTest.php
+++ b/tests/JqueryValidationAdapterTest.php
@@ -1,10 +1,17 @@
 <?php
 
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\Adapter\JqueryValidationAdapter;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\I18n\MessageTranslator;
-use UserFrosting\Support\Repository\Loader\YamlFileLoader;
 
 class JqueryValidationAdapterTest extends TestCase
 {
@@ -12,7 +19,7 @@ class JqueryValidationAdapterTest extends TestCase
 
     public function setUp()
     {
-        // Create a message translator        
+        // Create a message translator
         $this->translator = new MessageTranslator();
     }
 
@@ -54,9 +61,9 @@ class JqueryValidationAdapterTest extends TestCase
             'voles' => [
                 'validators' => [
                     'equals' => [
-                        'value' => 8,
+                        'value'         => 8,
                         'caseSensitive' => false,
-                        'message' => 'Voles must be equal to {{value}}.'
+                        'message'       => 'Voles must be equal to {{value}}.'
                     ]
                 ]
             ]
@@ -70,9 +77,9 @@ class JqueryValidationAdapterTest extends TestCase
             'rules' => [
                 'voles' => [
                     'equals' => [
-                        'value' => 8,
+                        'value'         => 8,
                         'caseSensitive' => false,
-                        'message' => 'Voles must be equal to {{value}}.'
+                        'message'       => 'Voles must be equal to {{value}}.'
                     ]
                 ]
             ],
@@ -122,9 +129,9 @@ class JqueryValidationAdapterTest extends TestCase
             'screech' => [
                 'validators' => [
                     'length' => [
-                        'min' => 5,
-                        'max' => 10,
-                        'message' => "Your screech must be between {{min}} and {{max}} characters long."
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.'
                     ]
                 ]
             ]
@@ -142,7 +149,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'screech' => [
-                    'rangelength' => "Your screech must be between 5 and 10 characters long."
+                    'rangelength' => 'Your screech must be between 5 and 10 characters long.'
                 ]
             ]
         ], $result);
@@ -155,8 +162,8 @@ class JqueryValidationAdapterTest extends TestCase
             'screech' => [
                 'validators' => [
                     'length' => [
-                        'min' => 5,
-                        'message' => "Your screech must be at least {{min}} characters long."
+                        'min'     => 5,
+                        'message' => 'Your screech must be at least {{min}} characters long.'
                     ]
                 ]
             ]
@@ -174,7 +181,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'screech' => [
-                    'minlength' => "Your screech must be at least 5 characters long."
+                    'minlength' => 'Your screech must be at least 5 characters long.'
                 ]
             ]
         ], $result);
@@ -187,8 +194,8 @@ class JqueryValidationAdapterTest extends TestCase
             'screech' => [
                 'validators' => [
                     'length' => [
-                        'max' => 10,
-                        'message' => "Your screech must be no more than {{max}} characters long."
+                        'max'     => 10,
+                        'message' => 'Your screech must be no more than {{max}} characters long.'
                     ]
                 ]
             ]
@@ -206,7 +213,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'screech' => [
-                    'maxlength' => "Your screech must be no more than 10 characters long."
+                    'maxlength' => 'Your screech must be no more than 10 characters long.'
                 ]
             ]
         ], $result);
@@ -219,7 +226,7 @@ class JqueryValidationAdapterTest extends TestCase
             'password' => [
                 'validators' => [
                     'matches' => [
-                        'field' => 'passwordc',
+                        'field'   => 'passwordc',
                         'message' => "The value of this field does not match the value of the '{{field}}' field."
                     ]
                 ]
@@ -251,8 +258,8 @@ class JqueryValidationAdapterTest extends TestCase
             'genus' => [
                 'validators' => [
                     'member_of' => [
-                        'values' => ["Megascops", "Bubo", "Glaucidium", "Tyto", "Athene"],
-                        'message' => "Sorry, that is not one of the permitted genuses."
+                        'values'  => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene'],
+                        'message' => 'Sorry, that is not one of the permitted genuses.'
                     ]
                 ]
             ]
@@ -265,12 +272,12 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'genus' => [
-                    'memberOf' => ["Megascops", "Bubo", "Glaucidium", "Tyto", "Athene"]
+                    'memberOf' => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene']
                 ]
             ],
             'messages' => [
                 'genus' => [
-                    'memberOf' => "Sorry, that is not one of the permitted genuses."
+                    'memberOf' => 'Sorry, that is not one of the permitted genuses.'
                 ]
             ]
         ], $result);
@@ -346,9 +353,9 @@ class JqueryValidationAdapterTest extends TestCase
             'voles' => [
                 'validators' => [
                     'not_equals' => [
-                        'value' => 0,
+                        'value'         => 0,
                         'caseSensitive' => false,
-                        'message' => 'Voles must not be equal to {{value}}.'
+                        'message'       => 'Voles must not be equal to {{value}}.'
                     ]
                 ]
             ]
@@ -362,9 +369,9 @@ class JqueryValidationAdapterTest extends TestCase
             'rules' => [
                 'voles' => [
                     'notEquals' => [
-                        'value' => 0,
+                        'value'         => 0,
                         'caseSensitive' => false,
-                        'message' => 'Voles must not be equal to {{value}}.'
+                        'message'       => 'Voles must not be equal to {{value}}.'
                     ]
                 ]
             ],
@@ -383,8 +390,8 @@ class JqueryValidationAdapterTest extends TestCase
             'password' => [
                 'validators' => [
                     'not_matches' => [
-                        'field' => 'user_name',
-                        'message' => "Your password cannot be the same as your username."
+                        'field'   => 'user_name',
+                        'message' => 'Your password cannot be the same as your username.'
                     ]
                 ]
             ]
@@ -402,7 +409,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'password' => [
-                    'notMatchFormField' => "Your password cannot be the same as your username."
+                    'notMatchFormField' => 'Your password cannot be the same as your username.'
                 ]
             ]
         ], $result);
@@ -415,8 +422,8 @@ class JqueryValidationAdapterTest extends TestCase
             'genus' => [
                 'validators' => [
                     'not_member_of' => [
-                        'values' => ["Myodes", "Microtus", "Neodon", "Alticola"],
-                        'message' => "Sorry, it would appear that you are not an owl."
+                        'values'  => ['Myodes', 'Microtus', 'Neodon', 'Alticola'],
+                        'message' => 'Sorry, it would appear that you are not an owl.'
                     ]
                 ]
             ]
@@ -429,12 +436,12 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'genus' => [
-                    'notMemberOf' => ["Myodes", "Microtus", "Neodon", "Alticola"]
+                    'notMemberOf' => ['Myodes', 'Microtus', 'Neodon', 'Alticola']
                 ]
             ],
             'messages' => [
                 'genus' => [
-                    'notMemberOf' => "Sorry, it would appear that you are not an owl."
+                    'notMemberOf' => 'Sorry, it would appear that you are not an owl.'
                 ]
             ]
         ], $result);
@@ -447,7 +454,7 @@ class JqueryValidationAdapterTest extends TestCase
             'accuracy' => [
                 'validators' => [
                     'numeric' => [
-                        'message' => "Sorry, your strike accuracy must be a number."
+                        'message' => 'Sorry, your strike accuracy must be a number.'
                     ]
                 ]
             ]
@@ -465,7 +472,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'accuracy' => [
-                    'number' => "Sorry, your strike accuracy must be a number."
+                    'number' => 'Sorry, your strike accuracy must be a number.'
                 ]
             ]
         ], $result);
@@ -478,9 +485,9 @@ class JqueryValidationAdapterTest extends TestCase
             'voles' => [
                 'validators' => [
                     'range' => [
-                        'min' => 5,
-                        'max' => 10,
-                        'message' => "You must catch {{min}} - {{max}} voles."
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'You must catch {{min}} - {{max}} voles.'
                     ]
                 ]
             ]
@@ -498,7 +505,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'voles' => [
-                    'range' => "You must catch 5 - 10 voles."
+                    'range' => 'You must catch 5 - 10 voles.'
                 ]
             ]
         ], $result);
@@ -511,8 +518,8 @@ class JqueryValidationAdapterTest extends TestCase
             'voles' => [
                 'validators' => [
                     'range' => [
-                        'min' => 5,
-                        'message' => "You must catch at least {{min}} voles."
+                        'min'     => 5,
+                        'message' => 'You must catch at least {{min}} voles.'
                     ]
                 ]
             ]
@@ -530,7 +537,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'voles' => [
-                    'min' => "You must catch at least 5 voles."
+                    'min' => 'You must catch at least 5 voles.'
                 ]
             ]
         ], $result);
@@ -543,8 +550,8 @@ class JqueryValidationAdapterTest extends TestCase
             'voles' => [
                 'validators' => [
                     'range' => [
-                        'max' => 10,
-                        'message' => "You must catch no more than {{max}} voles."
+                        'max'     => 10,
+                        'message' => 'You must catch no more than {{max}} voles.'
                     ]
                 ]
             ]
@@ -562,7 +569,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'voles' => [
-                    'max' => "You must catch no more than 10 voles."
+                    'max' => 'You must catch no more than 10 voles.'
                 ]
             ]
         ], $result);
@@ -575,8 +582,8 @@ class JqueryValidationAdapterTest extends TestCase
             'screech' => [
                 'validators' => [
                     'regex' => [
-                        'regex' => "^who(o*)$",
-                        'message' => "You did not provide a valid screech."
+                        'regex'   => '^who(o*)$',
+                        'message' => 'You did not provide a valid screech.'
                     ]
                 ]
             ]
@@ -589,12 +596,12 @@ class JqueryValidationAdapterTest extends TestCase
         $this->assertEquals([
             'rules' => [
                 'screech' => [
-                    'pattern' => "^who(o*)$"
+                    'pattern' => '^who(o*)$'
                 ]
             ],
             'messages' => [
                 'screech' => [
-                    'pattern' => "You did not provide a valid screech."
+                    'pattern' => 'You did not provide a valid screech.'
                 ]
             ]
         ], $result);
@@ -607,7 +614,7 @@ class JqueryValidationAdapterTest extends TestCase
             'species' => [
                 'validators' => [
                     'required' => [
-                        'message' => "Please tell us your species."
+                        'message' => 'Please tell us your species.'
                     ]
                 ]
             ]
@@ -625,7 +632,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'species' => [
-                    'required' => "Please tell us your species."
+                    'required' => 'Please tell us your species.'
                 ]
             ]
         ], $result);
@@ -638,7 +645,7 @@ class JqueryValidationAdapterTest extends TestCase
             'phone' => [
                 'validators' => [
                     'telephone' => [
-                        'message' => "Whoa there, check your phone number again."
+                        'message' => 'Whoa there, check your phone number again.'
                     ]
                 ]
             ]
@@ -656,7 +663,7 @@ class JqueryValidationAdapterTest extends TestCase
             ],
             'messages' => [
                 'phone' => [
-                    'phoneUS' => "Whoa there, check your phone number again."
+                    'phoneUS' => 'Whoa there, check your phone number again.'
                 ]
             ]
         ], $result);
@@ -724,7 +731,6 @@ class JqueryValidationAdapterTest extends TestCase
         ], $result);
     }
 
-
     public function testDomainRulesClientOnly()
     {
         // Arrange
@@ -732,7 +738,7 @@ class JqueryValidationAdapterTest extends TestCase
             'plumage' => [
                 'validators' => [
                     'required' => [
-                        'domain' => 'client',
+                        'domain'  => 'client',
                         'message' => "Are you sure you don't want to show us your plumage?"
                     ]
                 ]
@@ -771,7 +777,6 @@ class JqueryValidationAdapterTest extends TestCase
                 ]
             ]
         ], $result1);
-
     }
 
     public function testDomainRulesServerOnly()
@@ -781,7 +786,7 @@ class JqueryValidationAdapterTest extends TestCase
             'plumage' => [
                 'validators' => [
                     'required' => [
-                        'domain' => 'server',
+                        'domain'  => 'server',
                         'message' => "Are you sure you don't want to show us your plumage?"
                     ]
                 ]
@@ -813,412 +818,321 @@ class JqueryValidationAdapterTest extends TestCase
     public function testManyRules()
     {
         // Arrange
-        $schema = new RequestSchemaRepository(array(
-            'user_name' =>
-                array(
-                'validators' =>
-                    array(
-                    'length' =>
-                        array(
-                        'min' => 1,
-                        'max' => 50,
+        $schema = new RequestSchemaRepository([
+            'user_name' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 1,
+                        'max'     => 50,
                         'message' => 'ACCOUNT_USER_CHAR_LIMIT',
-                    ),
-                    'no_leading_whitespace' =>
-                        array(
+                    ],
+                    'no_leading_whitespace' => [
                         'message' => "'{{self}}' must not contain leading whitespace.",
-                    ),
-                    'no_trailing_whitespace' =>
-                        array(
+                    ],
+                    'no_trailing_whitespace' => [
                         'message' => "'{{self}}' must not contain trailing whitespace.",
-                    ),
-                    'required' =>
-                        array(
+                    ],
+                    'required' => [
                         'message' => 'ACCOUNT_SPECIFY_USERNAME',
-                    ),
-                    'username' =>
-                        array(
+                    ],
+                    'username' => [
                         'message' => "'{{self}}' must be a valid username.",
-                    ),
-                ),
-            ),
-            'display_name' =>
-                array(
-                'validators' =>
-                    array(
-                    'length' =>
-                        array(
-                        'min' => 1,
-                        'max' => 50,
+                    ],
+                ],
+            ],
+            'display_name' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 1,
+                        'max'     => 50,
                         'message' => 'ACCOUNT_DISPLAY_CHAR_LIMIT',
-                    ),
-                    'required' =>
-                        array(
+                    ],
+                    'required' => [
                         'message' => 'ACCOUNT_SPECIFY_DISPLAY_NAME',
-                    ),
-                ),
-            ),
-            'secret' =>
-                array(
-                'validators' =>
-                    array(
-                    'length' =>
-                        array(
-                        'min' => 1,
-                        'max' => 100,
+                    ],
+                ],
+            ],
+            'secret' => [
+                'validators' => [
+                    'length' => [
+                        'min'     => 1,
+                        'max'     => 100,
                         'message' => 'Secret must be between {{ min }} and {{ max }} characters long.',
-                        'domain' => 'client',
-                    ),
-                    'numeric' =>
-                        array(),
-                    'required' =>
-                        array(
+                        'domain'  => 'client',
+                    ],
+                    'numeric'  => [],
+                    'required' => [
                         'message' => 'Secret must be specified.',
-                        'domain' => 'server',
-                    ),
-                ),
-            ),
-            'puppies' =>
-                array(
-                'validators' =>
-                    array(
-                    'member_of' =>
-                        array(
-                        'values' =>
-                            array(
+                        'domain'  => 'server',
+                    ],
+                ],
+            ],
+            'puppies' => [
+                'validators' => [
+                    'member_of' => [
+                        'values' => [
                             0 => '0',
                             1 => '1',
-                        ),
+                        ],
                         'message' => "The value for '{{self}}' must be '0' or '1'.",
-                    ),
-                ),
-                'transformations' =>
-                    array(
+                    ],
+                ],
+                'transformations' => [
                     0 => 'purify',
                     1 => 'trim',
-                ),
-            ),
-            'phone' =>
-                array(
-                'validators' =>
-                    array(
-                    'telephone' =>
-                        array(
+                ],
+            ],
+            'phone' => [
+                'validators' => [
+                    'telephone' => [
                         'message' => "The value for '{{self}}' must be a valid telephone number.",
-                    ),
-                ),
-            ),
-            'email' =>
-                array(
-                'validators' =>
-                    array(
-                    'required' =>
-                        array(
+                    ],
+                ],
+            ],
+            'email' => [
+                'validators' => [
+                    'required' => [
                         'message' => 'ACCOUNT_SPECIFY_EMAIL'
-                    ),
-                    'length' =>
-                        array(
-                        'min' => 1,
-                        'max' => 100,
+                    ],
+                    'length' => [
+                        'min'     => 1,
+                        'max'     => 100,
                         'message' => 'ACCOUNT_EMAIL_CHAR_LIMIT'
-                    ),
-                    'email' =>
-                        array(
+                    ],
+                    'email' => [
                         'message' => 'ACCOUNT_INVALID_EMAIL'
-                    ),
-                )
-            ),
-            'password' =>
-                array(
-                'validators' =>
-                    array(
-                    'required' =>
-                        array(
+                    ],
+                ]
+            ],
+            'password' => [
+                'validators' => [
+                    'required' => [
                         'message' => 'ACCOUNT_SPECIFY_PASSWORD'
-                    ),
-                    'length' =>
-                        array(
-                        'min' => 8,
-                        'max' => 50,
+                    ],
+                    'length' => [
+                        'min'     => 8,
+                        'max'     => 50,
                         'message' => 'ACCOUNT_PASS_CHAR_LIMIT'
-                    ),
-                ),
-            ),
-            'passwordc' =>
-                array(
-                'validators' =>
-                    array(
-                    'required' =>
-                        array(
+                    ],
+                ],
+            ],
+            'passwordc' => [
+                'validators' => [
+                    'required' => [
                         'message' => 'ACCOUNT_SPECIFY_PASSWORD'
-                    ),
-                    'matches' =>
-                        array(
-                        'field' => 'password',
+                    ],
+                    'matches' => [
+                        'field'   => 'password',
                         'message' => 'ACCOUNT_PASS_MISMATCH'
-                    ),
-                    'length' =>
-                        array(
-                        'min' => 8,
-                        'max' => 50,
+                    ],
+                    'length' => [
+                        'min'     => 8,
+                        'max'     => 50,
                         'message' => 'ACCOUNT_PASS_CHAR_LIMIT'
-                    )
-                )
-            )
-        ));
+                    ]
+                ]
+            ]
+        ]);
 
         // Act
         $adapter = new JqueryValidationAdapter($schema, $this->translator);
         $result = $adapter->rules();
 
-        $this->assertEquals(array(
-            'rules' =>
-                array(
-                'user_name' =>
-                    array(
-                    'rangelength' =>
-                        array(
+        $this->assertEquals([
+            'rules' => [
+                'user_name' => [
+                    'rangelength' => [
                         0 => 1,
                         1 => 50
-                    ),
-                    'noLeadingWhitespace' => true,
+                    ],
+                    'noLeadingWhitespace'  => true,
                     'noTrailingWhitespace' => true,
-                    'required' => true,
-                    'username' => true
-                ),
-                'display_name' =>
-                    array(
-                    'rangelength' =>
-                        array(
+                    'required'             => true,
+                    'username'             => true
+                ],
+                'display_name' => [
+                    'rangelength' => [
                         0 => 1,
                         1 => 50,
-                    ),
+                    ],
                     'required' => true
-                ),
-                'secret' =>
-                    array(
-                    'rangelength' =>
-                        array(
+                ],
+                'secret' => [
+                    'rangelength' => [
                         0 => 1,
                         1 => 100
-                    ),
+                    ],
                     'number' => true
-                ),
-                'puppies' =>
-                    array(
-                    'memberOf' =>
-                        array(
+                ],
+                'puppies' => [
+                    'memberOf' => [
                         0 => '0',
                         1 => '1'
-                    )
-                ),
-                'phone' =>
-                    array(
+                    ]
+                ],
+                'phone' => [
                     'phoneUS' => true
-                ),
-                'email' =>
-                    array(
-                    'required' => true,
-                    'rangelength' =>
-                        array(
+                ],
+                'email' => [
+                    'required'    => true,
+                    'rangelength' => [
                         0 => 1,
                         1 => 100
-                    ),
+                    ],
                     'email' => true
-                ),
-                'password' =>
-                    array(
-                    'required' => true,
-                    'rangelength' =>
-                        array(
+                ],
+                'password' => [
+                    'required'    => true,
+                    'rangelength' => [
                         0 => 8,
                         1 => 50
-                    )
-                ),
-                'passwordc' =>
-                    array(
-                    'required' => true,
+                    ]
+                ],
+                'passwordc' => [
+                    'required'       => true,
                     'matchFormField' => 'password',
-                    'rangelength' =>
-                        array(
+                    'rangelength'    => [
                         0 => 8,
                         1 => 50
-                    )
-                )
-            ),
-            'messages' =>
-                array(
-                'user_name' =>
-                    array(
-                    'rangelength' => 'ACCOUNT_USER_CHAR_LIMIT',
-                    'noLeadingWhitespace' => "'user_name' must not contain leading whitespace.",
+                    ]
+                ]
+            ],
+            'messages' => [
+                'user_name' => [
+                    'rangelength'          => 'ACCOUNT_USER_CHAR_LIMIT',
+                    'noLeadingWhitespace'  => "'user_name' must not contain leading whitespace.",
                     'noTrailingWhitespace' => "'user_name' must not contain trailing whitespace.",
-                    'required' => 'ACCOUNT_SPECIFY_USERNAME',
-                    'username' => "'user_name' must be a valid username.",
-                ),
-                'display_name' =>
-                    array(
+                    'required'             => 'ACCOUNT_SPECIFY_USERNAME',
+                    'username'             => "'user_name' must be a valid username.",
+                ],
+                'display_name' => [
                     'rangelength' => 'ACCOUNT_DISPLAY_CHAR_LIMIT',
-                    'required' => 'ACCOUNT_SPECIFY_DISPLAY_NAME',
-                ),
-                'secret' =>
-                    array(
+                    'required'    => 'ACCOUNT_SPECIFY_DISPLAY_NAME',
+                ],
+                'secret' => [
                     'rangelength' => 'Secret must be between 1 and 100 characters long.',
-                ),
-                'puppies' =>
-                    array(
+                ],
+                'puppies' => [
                     'memberOf' => "The value for 'puppies' must be '0' or '1'.",
-                ),
-                'phone' =>
-                    array(
+                ],
+                'phone' => [
                     'phoneUS' => "The value for 'phone' must be a valid telephone number.",
-                ),
-                'email' =>
-                    array(
-                    'required' => 'ACCOUNT_SPECIFY_EMAIL',
+                ],
+                'email' => [
+                    'required'    => 'ACCOUNT_SPECIFY_EMAIL',
                     'rangelength' => 'ACCOUNT_EMAIL_CHAR_LIMIT',
-                    'email' => 'ACCOUNT_INVALID_EMAIL',
-                ),
-                'password' =>
-                    array(
-                    'required' => 'ACCOUNT_SPECIFY_PASSWORD',
+                    'email'       => 'ACCOUNT_INVALID_EMAIL',
+                ],
+                'password' => [
+                    'required'    => 'ACCOUNT_SPECIFY_PASSWORD',
                     'rangelength' => 'ACCOUNT_PASS_CHAR_LIMIT',
-                ),
-                'passwordc' =>
-                    array(
-                    'required' => 'ACCOUNT_SPECIFY_PASSWORD',
+                ],
+                'passwordc' => [
+                    'required'       => 'ACCOUNT_SPECIFY_PASSWORD',
                     'matchFormField' => 'ACCOUNT_PASS_MISMATCH',
-                    'rangelength' => 'ACCOUNT_PASS_CHAR_LIMIT'
-                )
-            ),
-        ), $result);
-
+                    'rangelength'    => 'ACCOUNT_PASS_CHAR_LIMIT'
+                ]
+            ],
+        ], $result);
 
         // Srinvas Nukala : Adding Test with Form array prefix 'coolform1'
         $result1 = $adapter->rules('json', false, 'coolform1');
 
-        $this->assertEquals(array(
-            'rules' =>
-                array(
-                'coolform1[user_name]' =>
-                    array(
-                    'rangelength' =>
-                        array(
+        $this->assertEquals([
+            'rules' => [
+                'coolform1[user_name]' => [
+                    'rangelength' => [
                         0 => 1,
                         1 => 50
-                    ),
-                    'noLeadingWhitespace' => true,
+                    ],
+                    'noLeadingWhitespace'  => true,
                     'noTrailingWhitespace' => true,
-                    'required' => true,
-                    'username' => true
-                ),
-                'coolform1[display_name]' =>
-                    array(
-                    'rangelength' =>
-                        array(
+                    'required'             => true,
+                    'username'             => true
+                ],
+                'coolform1[display_name]' => [
+                    'rangelength' => [
                         0 => 1,
                         1 => 50,
-                    ),
+                    ],
                     'required' => true
-                ),
-                'coolform1[secret]' =>
-                    array(
-                    'rangelength' =>
-                        array(
+                ],
+                'coolform1[secret]' => [
+                    'rangelength' => [
                         0 => 1,
                         1 => 100
-                    ),
+                    ],
                     'number' => true
-                ),
-                'coolform1[puppies]' =>
-                    array(
-                    'memberOf' =>
-                        array(
+                ],
+                'coolform1[puppies]' => [
+                    'memberOf' => [
                         0 => '0',
                         1 => '1'
-                    )
-                ),
-                'coolform1[phone]' =>
-                    array(
+                    ]
+                ],
+                'coolform1[phone]' => [
                     'phoneUS' => true
-                ),
-                'coolform1[email]' =>
-                    array(
-                    'required' => true,
-                    'rangelength' =>
-                        array(
+                ],
+                'coolform1[email]' => [
+                    'required'    => true,
+                    'rangelength' => [
                         0 => 1,
                         1 => 100
-                    ),
+                    ],
                     'email' => true
-                ),
-                'coolform1[password]' =>
-                    array(
-                    'required' => true,
-                    'rangelength' =>
-                        array(
+                ],
+                'coolform1[password]' => [
+                    'required'    => true,
+                    'rangelength' => [
                         0 => 8,
                         1 => 50
-                    )
-                ),
-                'coolform1[passwordc]' =>
-                    array(
-                    'required' => true,
+                    ]
+                ],
+                'coolform1[passwordc]' => [
+                    'required'       => true,
                     'matchFormField' => 'password',
-                    'rangelength' =>
-                        array(
+                    'rangelength'    => [
                         0 => 8,
                         1 => 50
-                    )
-                )
-            ),
-            'messages' =>
-                array(
-                'coolform1[user_name]' =>
-                    array(
-                    'rangelength' => 'ACCOUNT_USER_CHAR_LIMIT',
-                    'noLeadingWhitespace' => "'user_name' must not contain leading whitespace.",
+                    ]
+                ]
+            ],
+            'messages' => [
+                'coolform1[user_name]' => [
+                    'rangelength'          => 'ACCOUNT_USER_CHAR_LIMIT',
+                    'noLeadingWhitespace'  => "'user_name' must not contain leading whitespace.",
                     'noTrailingWhitespace' => "'user_name' must not contain trailing whitespace.",
-                    'required' => 'ACCOUNT_SPECIFY_USERNAME',
-                    'username' => "'user_name' must be a valid username.",
-                ),
-                'coolform1[display_name]' =>
-                    array(
+                    'required'             => 'ACCOUNT_SPECIFY_USERNAME',
+                    'username'             => "'user_name' must be a valid username.",
+                ],
+                'coolform1[display_name]' => [
                     'rangelength' => 'ACCOUNT_DISPLAY_CHAR_LIMIT',
-                    'required' => 'ACCOUNT_SPECIFY_DISPLAY_NAME',
-                ),
-                'coolform1[secret]' =>
-                    array(
+                    'required'    => 'ACCOUNT_SPECIFY_DISPLAY_NAME',
+                ],
+                'coolform1[secret]' => [
                     'rangelength' => 'Secret must be between 1 and 100 characters long.',
-                ),
-                'coolform1[puppies]' =>
-                    array(
+                ],
+                'coolform1[puppies]' => [
                     'memberOf' => "The value for 'puppies' must be '0' or '1'.",
-                ),
-                'coolform1[phone]' =>
-                    array(
+                ],
+                'coolform1[phone]' => [
                     'phoneUS' => "The value for 'phone' must be a valid telephone number.",
-                ),
-                'coolform1[email]' =>
-                    array(
-                    'required' => 'ACCOUNT_SPECIFY_EMAIL',
+                ],
+                'coolform1[email]' => [
+                    'required'    => 'ACCOUNT_SPECIFY_EMAIL',
                     'rangelength' => 'ACCOUNT_EMAIL_CHAR_LIMIT',
-                    'email' => 'ACCOUNT_INVALID_EMAIL',
-                ),
-                'coolform1[password]' =>
-                    array(
-                    'required' => 'ACCOUNT_SPECIFY_PASSWORD',
+                    'email'       => 'ACCOUNT_INVALID_EMAIL',
+                ],
+                'coolform1[password]' => [
+                    'required'    => 'ACCOUNT_SPECIFY_PASSWORD',
                     'rangelength' => 'ACCOUNT_PASS_CHAR_LIMIT',
-                ),
-                'coolform1[passwordc]' =>
-                    array(
-                    'required' => 'ACCOUNT_SPECIFY_PASSWORD',
+                ],
+                'coolform1[passwordc]' => [
+                    'required'       => 'ACCOUNT_SPECIFY_PASSWORD',
                     'matchFormField' => 'ACCOUNT_PASS_MISMATCH',
-                    'rangelength' => 'ACCOUNT_PASS_CHAR_LIMIT'
-                )
-            ),
-        ), $result1);
-
-
+                    'rangelength'    => 'ACCOUNT_PASS_CHAR_LIMIT'
+                ]
+            ],
+        ], $result1);
     }
 }

--- a/tests/RequestDataTransformerTest.php
+++ b/tests/RequestDataTransformerTest.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
  */
 
+namespace UserFrosting\Fortress\Tests;
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\RequestDataTransformer;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;

--- a/tests/RequestDataTransformerTest.php
+++ b/tests/RequestDataTransformerTest.php
@@ -23,16 +23,16 @@ class RequestDataTransformerTest extends TestCase
 
     public function setUp()
     {
-        $this->basePath = __DIR__ . '/data';
+        $this->basePath = __DIR__.'/data';
 
         // Arrange
-        $loader = new YamlFileLoader($this->basePath . '/register.yaml');
+        $loader = new YamlFileLoader($this->basePath.'/register.yaml');
         $schema = new RequestSchemaRepository($loader->load());
         $this->transformer = new RequestDataTransformer($schema);
     }
 
     /**
-     * Basic whitelisting
+     * Basic whitelisting.
      */
     public function testBasic()
     {
@@ -40,7 +40,7 @@ class RequestDataTransformerTest extends TestCase
         $rawInput = [
             'email'       => 'david@owlfancy.com',
             'admin'       => 1,
-            'description' => 'Some stuff to describe'
+            'description' => 'Some stuff to describe',
         ];
 
         // Arrange
@@ -48,7 +48,7 @@ class RequestDataTransformerTest extends TestCase
 
         $schema->mergeItems(null, [
             'email'       => [],
-            'description' => null  // Replicating an input that has no validation operations
+            'description' => null,  // Replicating an input that has no validation operations
         ]);
         $this->transformer = new RequestDataTransformer($schema);
 
@@ -58,20 +58,20 @@ class RequestDataTransformerTest extends TestCase
         // Assert
         $transformedData = [
             'email'       => 'david@owlfancy.com',
-            'description' => 'Some stuff to describe'
+            'description' => 'Some stuff to describe',
         ];
 
         $this->assertEquals($transformedData, $result);
     }
 
     /**
-     * "Trim" transformer
+     * "Trim" transformer.
      */
     public function testTrim()
     {
         // Act
         $rawInput = [
-            'display_name' => 'THE GREATEST  '
+            'display_name' => 'THE GREATEST  ',
         ];
 
         $result = $this->transformer->transform($rawInput, 'skip');
@@ -79,20 +79,20 @@ class RequestDataTransformerTest extends TestCase
         // Assert
         $transformedData = [
             'email'        => 'david@owlfancy.com',
-            'display_name' => 'THE GREATEST'
+            'display_name' => 'THE GREATEST',
         ];
 
         $this->assertEquals($transformedData, $result);
     }
 
     /**
-     * "Escape" transformer
+     * "Escape" transformer.
      */
     public function testEscape()
     {
         // Act
         $rawInput = [
-            'display_name' => '<b>My Super-Important Name</b>'
+            'display_name' => '<b>My Super-Important Name</b>',
         ];
 
         $result = $this->transformer->transform($rawInput, 'skip');
@@ -100,20 +100,20 @@ class RequestDataTransformerTest extends TestCase
         // Assert
         $transformedData = [
             'email'        => 'david@owlfancy.com',
-            'display_name' => '&#60;b&#62;My Super-Important Name&#60;/b&#62;'
+            'display_name' => '&#60;b&#62;My Super-Important Name&#60;/b&#62;',
         ];
 
         $this->assertEquals($transformedData, $result);
     }
 
     /**
-     * "Purge" transformer
+     * "Purge" transformer.
      */
     public function testPurge()
     {
         // Act
         $rawInput = [
-            'user_name' => '<b>My Super-Important Name</b>'
+            'user_name' => '<b>My Super-Important Name</b>',
         ];
 
         $result = $this->transformer->transform($rawInput, 'skip');
@@ -121,20 +121,20 @@ class RequestDataTransformerTest extends TestCase
         // Assert
         $transformedData = [
             'email'     => 'david@owlfancy.com',
-            'user_name' => 'My Super-Important Name'
+            'user_name' => 'My Super-Important Name',
         ];
 
         $this->assertEquals($transformedData, $result);
     }
 
     /**
-     * "Purify" transformer
+     * "Purify" transformer.
      */
     public function testPurify()
     {
         // Act
         $rawInput = [
-            'puppies' => "<script>I'm definitely really a puppy  </script><b>0</b>"
+            'puppies' => "<script>I'm definitely really a puppy  </script><b>0</b>",
         ];
 
         $result = $this->transformer->transform($rawInput, 'skip');
@@ -142,7 +142,7 @@ class RequestDataTransformerTest extends TestCase
         // Assert
         $transformedData = [
             'email'   => 'david@owlfancy.com',
-            'puppies' => '<b>0</b>'
+            'puppies' => '<b>0</b>',
         ];
 
         $this->assertEquals($transformedData, $result);

--- a/tests/RequestDataTransformerTest.php
+++ b/tests/RequestDataTransformerTest.php
@@ -1,7 +1,14 @@
 <?php
 
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
 use PHPUnit\Framework\TestCase;
-use UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Fortress\RequestDataTransformer;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Support\Repository\Loader\YamlFileLoader;
@@ -11,7 +18,7 @@ class RequestDataTransformerTest extends TestCase
     protected $basePath;
 
     protected $transformer;
-    
+
     public function setUp()
     {
         $this->basePath = __DIR__ . '/data';
@@ -29,8 +36,8 @@ class RequestDataTransformerTest extends TestCase
     {
         // Arrange
         $rawInput = [
-            'email' => 'david@owlfancy.com',
-            'admin' => 1,
+            'email'       => 'david@owlfancy.com',
+            'admin'       => 1,
             'description' => 'Some stuff to describe'
         ];
 
@@ -38,17 +45,17 @@ class RequestDataTransformerTest extends TestCase
         $schema = new RequestSchemaRepository();
 
         $schema->mergeItems(null, [
-            'email' => [],
+            'email'       => [],
             'description' => null  // Replicating an input that has no validation operations
         ]);
         $this->transformer = new RequestDataTransformer($schema);
-        
+
         // Act
         $result = $this->transformer->transform($rawInput, 'skip');
 
         // Assert
         $transformedData = [
-            'email' => 'david@owlfancy.com',
+            'email'       => 'david@owlfancy.com',
             'description' => 'Some stuff to describe'
         ];
 
@@ -62,15 +69,15 @@ class RequestDataTransformerTest extends TestCase
     {
         // Act
         $rawInput = [
-            'display_name' => "THE GREATEST  "
+            'display_name' => 'THE GREATEST  '
         ];
-        
+
         $result = $this->transformer->transform($rawInput, 'skip');
 
         // Assert
         $transformedData = [
-            'email' => 'david@owlfancy.com',
-            'display_name' => "THE GREATEST"
+            'email'        => 'david@owlfancy.com',
+            'display_name' => 'THE GREATEST'
         ];
 
         $this->assertEquals($transformedData, $result);
@@ -83,15 +90,15 @@ class RequestDataTransformerTest extends TestCase
     {
         // Act
         $rawInput = [
-            'display_name' => "<b>My Super-Important Name</b>"
+            'display_name' => '<b>My Super-Important Name</b>'
         ];
-        
+
         $result = $this->transformer->transform($rawInput, 'skip');
 
         // Assert
         $transformedData = [
-            'email' => 'david@owlfancy.com',
-            'display_name' => "&#60;b&#62;My Super-Important Name&#60;/b&#62;"
+            'email'        => 'david@owlfancy.com',
+            'display_name' => '&#60;b&#62;My Super-Important Name&#60;/b&#62;'
         ];
 
         $this->assertEquals($transformedData, $result);
@@ -104,15 +111,15 @@ class RequestDataTransformerTest extends TestCase
     {
         // Act
         $rawInput = [
-            'user_name' => "<b>My Super-Important Name</b>"
+            'user_name' => '<b>My Super-Important Name</b>'
         ];
-        
+
         $result = $this->transformer->transform($rawInput, 'skip');
 
         // Assert
         $transformedData = [
-            'email' => 'david@owlfancy.com',
-            'user_name' => "My Super-Important Name"
+            'email'     => 'david@owlfancy.com',
+            'user_name' => 'My Super-Important Name'
         ];
 
         $this->assertEquals($transformedData, $result);
@@ -127,13 +134,13 @@ class RequestDataTransformerTest extends TestCase
         $rawInput = [
             'puppies' => "<script>I'm definitely really a puppy  </script><b>0</b>"
         ];
-        
+
         $result = $this->transformer->transform($rawInput, 'skip');
 
         // Assert
         $transformedData = [
-            'email' => 'david@owlfancy.com',
-            'puppies' => "<b>0</b>"
+            'email'   => 'david@owlfancy.com',
+            'puppies' => '<b>0</b>'
         ];
 
         $this->assertEquals($transformedData, $result);

--- a/tests/RequestSchemaRepositoryTest.php
+++ b/tests/RequestSchemaRepositoryTest.php
@@ -85,6 +85,25 @@ class RequestSchemaRepositoryTest extends TestCase
         $this->assertArraySubset($contactSchema, $result);
     }
 
+    public function testSetDefaultWithMissingField()
+    {
+        // Arrange
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
+        $schema = new RequestSchemaRepository($loader->load());
+
+        // Act
+        $schema->setDefault('foo', 'bar');
+        $result = $schema->all();
+
+        // Assert
+        $contactSchema = [
+              'foo' => [
+                  'default' => 'bar',
+              ],
+          ];
+        $this->assertArraySubset($contactSchema, $result);
+    }
+
     public function testAddValidator()
     {
         // Arrange
@@ -105,6 +124,33 @@ class RequestSchemaRepositoryTest extends TestCase
                     'required' => [
                         'message' => 'Please enter a message',
                     ],
+                    'length' => [
+                        'max'     => 10000,
+                        'message' => 'Your message is too long!',
+                    ],
+                ],
+            ],
+        ];
+        $this->assertArraySubset($contactSchema, $result);
+    }
+
+    public function testAddValidatorWithMissingField()
+    {
+        // Arrange
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
+        $schema = new RequestSchemaRepository($loader->load());
+
+        // Act
+        $schema->addValidator('foo', 'length', [
+            'max'     => 10000,
+            'message' => 'Your message is too long!',
+        ]);
+        $result = $schema->all();
+
+        // Assert
+        $contactSchema = [
+            'foo' => [
+                'validators' => [
                     'length' => [
                         'max'     => 10000,
                         'message' => 'Your message is too long!',
@@ -173,6 +219,54 @@ class RequestSchemaRepositoryTest extends TestCase
                         'message' => 'Please enter a message',
                     ],
                 ],
+                'transformations' => [
+                    'purge',
+                    'owlify',
+                ],
+            ],
+        ];
+        $this->assertArraySubset($contactSchema, $result);
+    }
+
+    public function testSetTransformationNotAnArray()
+    {
+        // Arrange
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
+        $schema = new RequestSchemaRepository($loader->load());
+
+        // Act
+        $schema->setTransformations('message', 'purge');
+        $result = $schema->all();
+
+        // Assert
+        $contactSchema = [
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message',
+                    ],
+                ],
+                'transformations' => [
+                    'purge',
+                ],
+            ],
+        ];
+        $this->assertArraySubset($contactSchema, $result);
+    }
+
+    public function testSetTransformationWithMissingField()
+    {
+        // Arrange
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
+        $schema = new RequestSchemaRepository($loader->load());
+
+        // Act
+        $schema->setTransformations('foo', ['purge', 'owlify']);
+        $result = $schema->all();
+
+        // Assert
+        $contactSchema = [
+            'foo' => [
                 'transformations' => [
                     'purge',
                     'owlify',

--- a/tests/RequestSchemaRepositoryTest.php
+++ b/tests/RequestSchemaRepositoryTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Support\Repository\Loader\YamlFileLoader;
 
-class RequestSchemaTest extends TestCase
+class RequestSchemaRepositoryTest extends TestCase
 {
     protected $basePath;
 

--- a/tests/RequestSchemaTest.php
+++ b/tests/RequestSchemaTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace UserFrosting\Fortress\Tests;
+
+use PHPUnit\Framework\TestCase;
+use UserFrosting\Fortress\RequestSchema;
+
+class RequestSchemaTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->basePath = __DIR__.'/data/contact.json';
+
+        $this->contactSchema = [
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testWithNoPath()
+    {
+        $requestSchema = new RequestSchema();
+        $this->assertSame([], $requestSchema->getSchema());
+        $this->assertSame($requestSchema->all(), $requestSchema->getSchema());
+    }
+
+    public function testWithPath()
+    {
+        $requestSchema = new RequestSchema($this->basePath);
+        $this->assertArraySubset($this->contactSchema, $requestSchema->getSchema());
+        $this->assertSame($requestSchema->all(), $requestSchema->getSchema());
+    }
+}

--- a/tests/RequestSchemaTest.php
+++ b/tests/RequestSchemaTest.php
@@ -22,23 +22,23 @@ class RequestSchemaTest extends TestCase
 
     public function setUp()
     {
-        $this->basePath = __DIR__ . '/data';
+        $this->basePath = __DIR__.'/data';
 
         $this->contactSchema = [
             'message' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please enter a message'
-                    ]
-                ]
-            ]
+                        'message' => 'Please enter a message',
+                    ],
+                ],
+            ],
         ];
     }
 
     public function testReadJsonSchema()
     {
         // Arrange
-        $loader = new YamlFileLoader($this->basePath . '/contact.json');
+        $loader = new YamlFileLoader($this->basePath.'/contact.json');
         $schema = new RequestSchemaRepository($loader->load());
 
         // Act
@@ -51,7 +51,7 @@ class RequestSchemaTest extends TestCase
     public function testReadYamlSchema()
     {
         // Arrange
-        $loader = new YamlFileLoader($this->basePath . '/contact.yaml');
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
         $schema = new RequestSchemaRepository($loader->load());
 
         // Act
@@ -64,7 +64,7 @@ class RequestSchemaTest extends TestCase
     public function testSetDefault()
     {
         // Arrange
-        $loader = new YamlFileLoader($this->basePath . '/contact.yaml');
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
         $schema = new RequestSchemaRepository($loader->load());
 
         // Act
@@ -77,10 +77,10 @@ class RequestSchemaTest extends TestCase
                 'default'    => 'I require more voles.',
                 'validators' => [
                     'required' => [
-                        'message' => 'Please enter a message'
-                    ]
-                ]
-            ]
+                        'message' => 'Please enter a message',
+                    ],
+                ],
+            ],
         ];
         $this->assertArraySubset($contactSchema, $result);
     }
@@ -88,13 +88,13 @@ class RequestSchemaTest extends TestCase
     public function testAddValidator()
     {
         // Arrange
-        $loader = new YamlFileLoader($this->basePath . '/contact.yaml');
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
         $schema = new RequestSchemaRepository($loader->load());
 
         // Act
         $schema->addValidator('message', 'length', [
             'max'     => 10000,
-            'message' => 'Your message is too long!'
+            'message' => 'Your message is too long!',
         ]);
         $result = $schema->all();
 
@@ -103,14 +103,14 @@ class RequestSchemaTest extends TestCase
             'message' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please enter a message'
+                        'message' => 'Please enter a message',
                     ],
                     'length' => [
                         'max'     => 10000,
-                        'message' => 'Your message is too long!'
-                    ]
-                ]
-            ]
+                        'message' => 'Your message is too long!',
+                    ],
+                ],
+            ],
         ];
         $this->assertArraySubset($contactSchema, $result);
     }
@@ -122,14 +122,14 @@ class RequestSchemaTest extends TestCase
             'message' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please enter a message'
+                        'message' => 'Please enter a message',
                     ],
                     'length' => [
                         'max'     => 10000,
-                        'message' => 'Your message is too long!'
-                    ]
-                ]
-            ]
+                        'message' => 'Your message is too long!',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -146,10 +146,10 @@ class RequestSchemaTest extends TestCase
                 'validators' => [
                     'length' => [
                         'max'     => 10000,
-                        'message' => 'Your message is too long!'
-                    ]
-                ]
-            ]
+                        'message' => 'Your message is too long!',
+                    ],
+                ],
+            ],
         ];
 
         $this->assertEquals($contactSchema, $result);
@@ -158,7 +158,7 @@ class RequestSchemaTest extends TestCase
     public function testSetTransformation()
     {
         // Arrange
-        $loader = new YamlFileLoader($this->basePath . '/contact.yaml');
+        $loader = new YamlFileLoader($this->basePath.'/contact.yaml');
         $schema = new RequestSchemaRepository($loader->load());
 
         // Act
@@ -170,14 +170,14 @@ class RequestSchemaTest extends TestCase
             'message' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please enter a message'
-                    ]
+                        'message' => 'Please enter a message',
+                    ],
                 ],
                 'transformations' => [
                     'purge',
-                    'owlify'
-                ]
-            ]
+                    'owlify',
+                ],
+            ],
         ];
         $this->assertArraySubset($contactSchema, $result);
     }

--- a/tests/RequestSchemaTest.php
+++ b/tests/RequestSchemaTest.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
  */
 
+namespace UserFrosting\Fortress\Tests;
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Support\Repository\Loader\YamlFileLoader;

--- a/tests/RequestSchemaTest.php
+++ b/tests/RequestSchemaTest.php
@@ -1,7 +1,14 @@
 <?php
 
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
 use PHPUnit\Framework\TestCase;
-use UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Support\Repository\Loader\YamlFileLoader;
 
@@ -10,16 +17,16 @@ class RequestSchemaTest extends TestCase
     protected $basePath;
 
     protected $contactSchema;
-    
+
     public function setUp()
     {
         $this->basePath = __DIR__ . '/data';
 
         $this->contactSchema = [
-            "message" => [
-                "validators" => [
-                    "required" => [
-                        "message" => "Please enter a message"
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message'
                     ]
                 ]
             ]
@@ -59,16 +66,16 @@ class RequestSchemaTest extends TestCase
         $schema = new RequestSchemaRepository($loader->load());
 
         // Act
-        $schema->setDefault('message', "I require more voles.");
+        $schema->setDefault('message', 'I require more voles.');
         $result = $schema->all();
 
         // Assert
         $contactSchema = [
-            "message" => [
-                "default" => "I require more voles.",
-                "validators" => [
-                    "required" => [
-                        "message" => "Please enter a message"
+            'message' => [
+                'default'    => 'I require more voles.',
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message'
                     ]
                 ]
             ]
@@ -84,21 +91,21 @@ class RequestSchemaTest extends TestCase
 
         // Act
         $schema->addValidator('message', 'length', [
-            'max' => 10000,
+            'max'     => 10000,
             'message' => 'Your message is too long!'
         ]);
         $result = $schema->all();
 
         // Assert
         $contactSchema = [
-            "message" => [
-                "validators" => [
-                    "required" => [
-                        "message" => "Please enter a message"
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message'
                     ],
-                    "length" => [
-                        "max" => 10000,
-                        "message" => "Your message is too long!"
+                    'length' => [
+                        'max'     => 10000,
+                        'message' => 'Your message is too long!'
                     ]
                 ]
             ]
@@ -110,14 +117,14 @@ class RequestSchemaTest extends TestCase
     {
         // Arrange
         $schema = new RequestSchemaRepository([
-            "message" => [
-                "validators" => [
-                    "required" => [
-                        "message" => "Please enter a message"
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message'
                     ],
-                    "length" => [
-                        "max" => 10000,
-                        "message" => "Your message is too long!"
+                    'length' => [
+                        'max'     => 10000,
+                        'message' => 'Your message is too long!'
                     ]
                 ]
             ]
@@ -133,11 +140,11 @@ class RequestSchemaTest extends TestCase
 
         // Assert
         $contactSchema = [
-            "message" => [
-                "validators" => [
-                    "length" => [
-                        "max" => 10000,
-                        "message" => "Your message is too long!"
+            'message' => [
+                'validators' => [
+                    'length' => [
+                        'max'     => 10000,
+                        'message' => 'Your message is too long!'
                     ]
                 ]
             ]
@@ -158,15 +165,15 @@ class RequestSchemaTest extends TestCase
 
         // Assert
         $contactSchema = [
-            "message" => [
-                "validators" => [
-                    "required" => [
-                        "message" => "Please enter a message"
+            'message' => [
+                'validators' => [
+                    'required' => [
+                        'message' => 'Please enter a message'
                     ]
                 ],
-                "transformations" => [
-                    "purge",
-                    "owlify"
+                'transformations' => [
+                    'purge',
+                    'owlify'
                 ]
             ]
         ];

--- a/tests/ServerSideValidatorTest.php
+++ b/tests/ServerSideValidatorTest.php
@@ -1,18 +1,25 @@
 <?php
 
+/*
+ * UserFrosting Fortress (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/fortress
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
+ */
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Fortress\ServerSideValidator;
 use UserFrosting\I18n\MessageTranslator;
 
-
 class ServerSideValidatorTest extends TestCase
 {
     protected $translator;
-    
+
     public function setUp()
     {
-        // Create a message translator        
+        // Create a message translator
         $this->translator = new MessageTranslator();
     }
 
@@ -55,9 +62,9 @@ class ServerSideValidatorTest extends TestCase
             'voles' => [
                 'validators' => [
                     'equals' => [
-                        'value' => 8,
+                        'value'         => 8,
                         'caseSensitive' => false,
-                        'message' => 'Voles must be equal to {{value}}.'
+                        'message'       => 'Voles must be equal to {{value}}.'
                     ]
                 ]
             ]
@@ -125,9 +132,9 @@ class ServerSideValidatorTest extends TestCase
             'screech' => [
                 'validators' => [
                     'length' => [
-                        'min' => 5,
-                        'max' => 10,
-                        'message' => "Your screech must be between {{min}} and {{max}} characters long."
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.'
                     ]
                 ]
             ]
@@ -163,8 +170,8 @@ class ServerSideValidatorTest extends TestCase
             'screech' => [
                 'validators' => [
                     'length' => [
-                        'min' => 5,
-                        'message' => "Your screech must be at least {{min}} characters long."
+                        'min'     => 5,
+                        'message' => 'Your screech must be at least {{min}} characters long.'
                     ]
                 ]
             ]
@@ -196,8 +203,8 @@ class ServerSideValidatorTest extends TestCase
             'screech' => [
                 'validators' => [
                     'length' => [
-                        'max' => 10,
-                        'message' => "Your screech must be no more than {{max}} characters long."
+                        'max'     => 10,
+                        'message' => 'Your screech must be no more than {{max}} characters long.'
                     ]
                 ]
             ]
@@ -228,7 +235,7 @@ class ServerSideValidatorTest extends TestCase
             'password' => [
                 'validators' => [
                     'matches' => [
-                        'field' => 'passwordc',
+                        'field'   => 'passwordc',
                         'message' => "The value of this field does not match the value of the '{{field}}' field."
                     ]
                 ]
@@ -239,7 +246,7 @@ class ServerSideValidatorTest extends TestCase
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'password' => 'secret',
+            'password'  => 'secret',
             'passwordc' => 'secret'
         ]);
 
@@ -250,7 +257,7 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'password' => 'secret',
+            'password'  => 'secret',
             'passwordc' => 'hoothoot'
         ]));
     }
@@ -262,8 +269,8 @@ class ServerSideValidatorTest extends TestCase
             'genus' => [
                 'validators' => [
                     'member_of' => [
-                        'values' => ["Megascops", "Bubo", "Glaucidium", "Tyto", "Athene"],
-                        'message' => "Sorry, that is not one of the permitted genuses."
+                        'values'  => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene'],
+                        'message' => 'Sorry, that is not one of the permitted genuses.'
                     ]
                 ]
             ]
@@ -294,7 +301,7 @@ class ServerSideValidatorTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'no_leading_whitespace' => [
-                        'message' => "{{self}} cannot begin with whitespace characters"
+                        'message' => '{{self}} cannot begin with whitespace characters'
                     ]
                 ]
             ]
@@ -322,7 +329,7 @@ class ServerSideValidatorTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'no_trailing_whitespace' => [
-                        'message' => "{{self}} cannot end with whitespace characters"
+                        'message' => '{{self}} cannot end with whitespace characters'
                     ]
                 ]
             ]
@@ -356,9 +363,9 @@ class ServerSideValidatorTest extends TestCase
             'voles' => [
                 'validators' => [
                     'not_equals' => [
-                        'value' => 0,
+                        'value'         => 0,
                         'caseSensitive' => false,
-                        'message' => 'Voles must be not be equal to {{value}}.'
+                        'message'       => 'Voles must be not be equal to {{value}}.'
                     ]
                 ]
             ]
@@ -390,8 +397,8 @@ class ServerSideValidatorTest extends TestCase
             'password' => [
                 'validators' => [
                     'not_matches' => [
-                        'field' => 'user_name',
-                        'message' => "Your password cannot be the same as your username."
+                        'field'   => 'user_name',
+                        'message' => 'Your password cannot be the same as your username.'
                     ]
                 ]
             ]
@@ -401,7 +408,7 @@ class ServerSideValidatorTest extends TestCase
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'password' => 'secret',
+            'password'  => 'secret',
             'user_name' => 'alexw'
         ]);
 
@@ -412,7 +419,7 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'password' => 'secret',
+            'password'  => 'secret',
             'user_name' => 'secret'
         ]));
     }
@@ -424,8 +431,8 @@ class ServerSideValidatorTest extends TestCase
             'genus' => [
                 'validators' => [
                     'not_member_of' => [
-                        'values' => ["Myodes", "Microtus", "Neodon", "Alticola"],
-                        'message' => "Sorry, it would appear that you are not an owl."
+                        'values'  => ['Myodes', 'Microtus', 'Neodon', 'Alticola'],
+                        'message' => 'Sorry, it would appear that you are not an owl.'
                     ]
                 ]
             ]
@@ -456,7 +463,7 @@ class ServerSideValidatorTest extends TestCase
             'accuracy' => [
                 'validators' => [
                     'numeric' => [
-                        'message' => "Sorry, your strike accuracy must be a number."
+                        'message' => 'Sorry, your strike accuracy must be a number.'
                     ]
                 ]
             ]
@@ -499,9 +506,9 @@ class ServerSideValidatorTest extends TestCase
             'voles' => [
                 'validators' => [
                     'range' => [
-                        'min' => 5,
-                        'max' => 10,
-                        'message' => "You must catch {{min}} - {{max}} voles."
+                        'min'     => 5,
+                        'max'     => 10,
+                        'message' => 'You must catch {{min}} - {{max}} voles.'
                     ]
                 ]
             ]
@@ -541,8 +548,8 @@ class ServerSideValidatorTest extends TestCase
             'screech' => [
                 'validators' => [
                     'regex' => [
-                        'regex' => "^who(o*)$",
-                        'message' => "You did not provide a valid screech."
+                        'regex'   => '^who(o*)$',
+                        'message' => 'You did not provide a valid screech.'
                     ]
                 ]
             ]
@@ -577,7 +584,7 @@ class ServerSideValidatorTest extends TestCase
             'species' => [
                 'validators' => [
                     'required' => [
-                        'message' => "Please tell us your species."
+                        'message' => 'Please tell us your species.'
                     ]
                 ]
             ]
@@ -610,7 +617,7 @@ class ServerSideValidatorTest extends TestCase
             'phone' => [
                 'validators' => [
                     'telephone' => [
-                        'message' => "Whoa there, check your phone number again."
+                        'message' => 'Whoa there, check your phone number again.'
                     ]
                 ]
             ]
@@ -761,7 +768,7 @@ class ServerSideValidatorTest extends TestCase
             'plumage' => [
                 'validators' => [
                     'required' => [
-                        'domain' => 'client',
+                        'domain'  => 'client',
                         'message' => "Are you sure you don't want to show us your plumage?"
                     ]
                 ]
@@ -787,7 +794,7 @@ class ServerSideValidatorTest extends TestCase
             'plumage' => [
                 'validators' => [
                     'required' => [
-                        'domain' => 'server',
+                        'domain'  => 'server',
                         'message' => "Are you sure you don't want to show us your plumage?"
                     ]
                 ]

--- a/tests/ServerSideValidatorTest.php
+++ b/tests/ServerSideValidatorTest.php
@@ -25,6 +25,24 @@ class ServerSideValidatorTest extends TestCase
         $this->translator = new MessageTranslator();
     }
 
+    public function testValidateNoValidators()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'email' => [],
+        ]);
+
+        // Act
+        $validator = new ServerSideValidator($schema, $this->translator);
+
+        $result = $validator->validate([
+            'email' => 'david@owlfancy.com',
+        ]);
+
+        // Check passing validation
+        $this->assertTrue($result);
+    }
+
     public function testValidateEmail()
     {
         // Arrange
@@ -53,6 +71,37 @@ class ServerSideValidatorTest extends TestCase
         // Check failing validation
         $this->assertFalse($validator->validate([
             'email' => 'screeeech',
+        ]));
+    }
+
+    public function testValidateArray()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'array' => [
+                'validators' => [
+                    'array' => [
+                    ],
+                ],
+            ],
+        ]);
+
+        // Act
+        $validator = new ServerSideValidator($schema, $this->translator);
+
+        $result = $validator->validate([
+            'array' => ['foo', 'bar'],
+        ]);
+
+        // Check that the correct Valitron rule was generated
+        $this->assertTrue($validator->hasRule('array', 'array'));
+
+        // Check passing validation
+        $this->assertTrue($result);
+
+        // Check failing validation
+        $this->assertFalse($validator->validate([
+            'array' => 'screeeech',
         ]));
     }
 

--- a/tests/ServerSideValidatorTest.php
+++ b/tests/ServerSideValidatorTest.php
@@ -8,6 +8,8 @@
  * @license   https://github.com/userfrosting/fortress/blob/master/LICENSE.md (MIT License)
  */
 
+namespace UserFrosting\Fortress\Tests;
+
 use PHPUnit\Framework\TestCase;
 use UserFrosting\Fortress\RequestSchema\RequestSchemaRepository;
 use UserFrosting\Fortress\ServerSideValidator;

--- a/tests/ServerSideValidatorTest.php
+++ b/tests/ServerSideValidatorTest.php
@@ -81,6 +81,7 @@ class ServerSideValidatorTest extends TestCase
             'array' => [
                 'validators' => [
                     'array' => [
+                        'message' => 'Array must be an array.',
                     ],
                 ],
             ],

--- a/tests/ServerSideValidatorTest.php
+++ b/tests/ServerSideValidatorTest.php
@@ -78,7 +78,7 @@ class ServerSideValidatorTest extends TestCase
     {
         // Arrange
         $schema = new RequestSchemaRepository([
-            'array' => [
+            'screech' => [
                 'validators' => [
                     'array' => [
                         'message' => 'Array must be an array.',
@@ -91,18 +91,18 @@ class ServerSideValidatorTest extends TestCase
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'array' => ['foo', 'bar'],
+            'screech' => ['foo', 'bar'],
         ]);
 
         // Check that the correct Valitron rule was generated
-        $this->assertTrue($validator->hasRule('array', 'array'));
+        $this->assertTrue($validator->hasRule('array', 'screech'));
 
         // Check passing validation
         $this->assertTrue($result);
 
         // Check failing validation
         $this->assertFalse($validator->validate([
-            'array' => 'screeeech',
+            'screech' => 'screeeech',
         ]));
     }
 
@@ -863,5 +863,33 @@ class ServerSideValidatorTest extends TestCase
 
         // Check passing validation
         $this->assertFalse($result);
+    }
+
+    /**
+     * @depends testValidateUsername
+     */
+    public function testValidateWithNoValidatorMessage()
+    {
+        // Arrange
+        $schema = new RequestSchemaRepository([
+            'user_name' => [
+                'validators' => [
+                    'username' => [],
+                ],
+            ],
+        ]);
+
+        // Act
+        $validator = new ServerSideValidator($schema, $this->translator);
+
+        $result = $validator->validate([
+            'user_name' => 'alex.weissman',
+        ]);
+
+        // Check that the correct Valitron rule was generated
+        $this->assertTrue($validator->hasRule('username', 'user_name'));
+
+        // Check passing validation
+        $this->assertTrue($result);
     }
 }

--- a/tests/ServerSideValidatorTest.php
+++ b/tests/ServerSideValidatorTest.php
@@ -32,16 +32,16 @@ class ServerSideValidatorTest extends TestCase
             'email' => [
                 'validators' => [
                     'email' => [
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'email' => 'david@owlfancy.com'
+            'email' => 'david@owlfancy.com',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -52,7 +52,7 @@ class ServerSideValidatorTest extends TestCase
 
         // Check failing validation
         $this->assertFalse($validator->validate([
-            'email' => 'screeeech'
+            'email' => 'screeeech',
         ]));
     }
 
@@ -66,17 +66,17 @@ class ServerSideValidatorTest extends TestCase
                     'equals' => [
                         'value'         => 8,
                         'caseSensitive' => false,
-                        'message'       => 'Voles must be equal to {{value}}.'
-                    ]
-                ]
-            ]
+                        'message'       => 'Voles must be equal to {{value}}.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'voles' => 8
+            'voles' => 8,
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -87,7 +87,7 @@ class ServerSideValidatorTest extends TestCase
 
         // Check failing validation
         $this->assertFalse($validator->validate([
-            'voles' => 3
+            'voles' => 3,
         ]));
     }
 
@@ -98,17 +98,17 @@ class ServerSideValidatorTest extends TestCase
             'voles' => [
                 'validators' => [
                     'integer' => [
-                        'message' => 'Voles must be numeric.'
-                    ]
-                ]
-            ]
+                        'message' => 'Voles must be numeric.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'voles' => 8
+            'voles' => 8,
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -119,11 +119,11 @@ class ServerSideValidatorTest extends TestCase
 
         // Check failing validations
         $this->assertFalse($validator->validate([
-            'voles' => 'yes'
+            'voles' => 'yes',
         ]));
 
         $this->assertFalse($validator->validate([
-            'voles' => 0.5
+            'voles' => 0.5,
         ]));
     }
 
@@ -136,17 +136,17 @@ class ServerSideValidatorTest extends TestCase
                     'length' => [
                         'min'     => 5,
                         'max'     => 10,
-                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your screech must be between {{min}} and {{max}} characters long.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'screech' => 'cawwwwww'
+            'screech' => 'cawwwwww',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -157,11 +157,11 @@ class ServerSideValidatorTest extends TestCase
 
         // Check failing validations
         $this->assertFalse($validator->validate([
-            'screech' => 'caw'
+            'screech' => 'caw',
         ]));
 
         $this->assertFalse($validator->validate([
-            'screech' => 'cawwwwwwwwwwwwwwwwwww'
+            'screech' => 'cawwwwwwwwwwwwwwwwwww',
         ]));
     }
 
@@ -173,17 +173,17 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'length' => [
                         'min'     => 5,
-                        'message' => 'Your screech must be at least {{min}} characters long.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your screech must be at least {{min}} characters long.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'screech' => 'cawwwwww'
+            'screech' => 'cawwwwww',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -194,7 +194,7 @@ class ServerSideValidatorTest extends TestCase
 
         // Check failing validations
         $this->assertFalse($validator->validate([
-            'screech' => 'caw'
+            'screech' => 'caw',
         ]));
     }
 
@@ -206,17 +206,17 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'length' => [
                         'max'     => 10,
-                        'message' => 'Your screech must be no more than {{max}} characters long.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your screech must be no more than {{max}} characters long.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'screech' => 'cawwwwww'
+            'screech' => 'cawwwwww',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -226,7 +226,7 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'screech' => 'cawwwwwwwwwwwwwwwwwww'
+            'screech' => 'cawwwwwwwwwwwwwwwwwww',
         ]));
     }
 
@@ -238,10 +238,10 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'matches' => [
                         'field'   => 'passwordc',
-                        'message' => "The value of this field does not match the value of the '{{field}}' field."
-                    ]
-                ]
-            ]
+                        'message' => "The value of this field does not match the value of the '{{field}}' field.",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -249,7 +249,7 @@ class ServerSideValidatorTest extends TestCase
 
         $result = $validator->validate([
             'password'  => 'secret',
-            'passwordc' => 'secret'
+            'passwordc' => 'secret',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -260,7 +260,7 @@ class ServerSideValidatorTest extends TestCase
 
         $this->assertFalse($validator->validate([
             'password'  => 'secret',
-            'passwordc' => 'hoothoot'
+            'passwordc' => 'hoothoot',
         ]));
     }
 
@@ -272,17 +272,17 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'member_of' => [
                         'values'  => ['Megascops', 'Bubo', 'Glaucidium', 'Tyto', 'Athene'],
-                        'message' => 'Sorry, that is not one of the permitted genuses.'
-                    ]
-                ]
-            ]
+                        'message' => 'Sorry, that is not one of the permitted genuses.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'genus' => 'Megascops'
+            'genus' => 'Megascops',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -292,7 +292,7 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'genus' => 'Dolomedes'
+            'genus' => 'Dolomedes',
         ]));
     }
 
@@ -303,24 +303,24 @@ class ServerSideValidatorTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'no_leading_whitespace' => [
-                        'message' => '{{self}} cannot begin with whitespace characters'
-                    ]
-                ]
-            ]
+                        'message' => '{{self}} cannot begin with whitespace characters',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'user_name' => 'alexw'
+            'user_name' => 'alexw',
         ]);
 
         // Check passing validation
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'user_name' => ' alexw'
+            'user_name' => ' alexw',
         ]));
     }
 
@@ -331,17 +331,17 @@ class ServerSideValidatorTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'no_trailing_whitespace' => [
-                        'message' => '{{self}} cannot end with whitespace characters'
-                    ]
-                ]
-            ]
+                        'message' => '{{self}} cannot end with whitespace characters',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'user_name' => 'alexw'
+            'user_name' => 'alexw',
         ]);
 
         // Check passing validation
@@ -349,11 +349,11 @@ class ServerSideValidatorTest extends TestCase
 
         // Should still allow starting with whitespace
         $this->assertTrue($validator->validate([
-            'user_name' => ' alexw'
+            'user_name' => ' alexw',
         ]));
 
         $this->assertFalse($validator->validate([
-            'user_name' => 'alexw '
+            'user_name' => 'alexw ',
         ]));
     }
 
@@ -367,17 +367,17 @@ class ServerSideValidatorTest extends TestCase
                     'not_equals' => [
                         'value'         => 0,
                         'caseSensitive' => false,
-                        'message'       => 'Voles must be not be equal to {{value}}.'
-                    ]
-                ]
-            ]
+                        'message'       => 'Voles must be not be equal to {{value}}.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'voles' => 8
+            'voles' => 8,
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -388,7 +388,7 @@ class ServerSideValidatorTest extends TestCase
 
         // Check failing validation
         $this->assertFalse($validator->validate([
-            'voles' => 0
+            'voles' => 0,
         ]));
     }
 
@@ -400,10 +400,10 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'not_matches' => [
                         'field'   => 'user_name',
-                        'message' => 'Your password cannot be the same as your username.'
-                    ]
-                ]
-            ]
+                        'message' => 'Your password cannot be the same as your username.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -411,7 +411,7 @@ class ServerSideValidatorTest extends TestCase
 
         $result = $validator->validate([
             'password'  => 'secret',
-            'user_name' => 'alexw'
+            'user_name' => 'alexw',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -422,7 +422,7 @@ class ServerSideValidatorTest extends TestCase
 
         $this->assertFalse($validator->validate([
             'password'  => 'secret',
-            'user_name' => 'secret'
+            'user_name' => 'secret',
         ]));
     }
 
@@ -434,17 +434,17 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'not_member_of' => [
                         'values'  => ['Myodes', 'Microtus', 'Neodon', 'Alticola'],
-                        'message' => 'Sorry, it would appear that you are not an owl.'
-                    ]
-                ]
-            ]
+                        'message' => 'Sorry, it would appear that you are not an owl.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'genus' => 'Megascops'
+            'genus' => 'Megascops',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -454,7 +454,7 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'genus' => 'Myodes'
+            'genus' => 'Myodes',
         ]));
     }
 
@@ -465,17 +465,17 @@ class ServerSideValidatorTest extends TestCase
             'accuracy' => [
                 'validators' => [
                     'numeric' => [
-                        'message' => 'Sorry, your strike accuracy must be a number.'
-                    ]
-                ]
-            ]
+                        'message' => 'Sorry, your strike accuracy must be a number.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'accuracy' => 0.99
+            'accuracy' => 0.99,
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -485,19 +485,19 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertTrue($validator->validate([
-            'accuracy' => '0.99'
+            'accuracy' => '0.99',
         ]));
 
         $this->assertTrue($validator->validate([
-            'accuracy' => ''
+            'accuracy' => '',
         ]));
 
         $this->assertFalse($validator->validate([
-            'accuracy' => false
+            'accuracy' => false,
         ]));
 
         $this->assertFalse($validator->validate([
-            'accuracy' => 'yes'
+            'accuracy' => 'yes',
         ]));
     }
 
@@ -510,17 +510,17 @@ class ServerSideValidatorTest extends TestCase
                     'range' => [
                         'min'     => 5,
                         'max'     => 10,
-                        'message' => 'You must catch {{min}} - {{max}} voles.'
-                    ]
-                ]
-            ]
+                        'message' => 'You must catch {{min}} - {{max}} voles.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'voles' => 6
+            'voles' => 6,
         ]);
 
         // Check that the correct Valitron rules were generated
@@ -531,15 +531,15 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'voles' => 2
+            'voles' => 2,
         ]));
 
         $this->assertFalse($validator->validate([
-            'voles' => 10000
+            'voles' => 10000,
         ]));
 
         $this->assertFalse($validator->validate([
-            'voles' => 'yes'
+            'voles' => 'yes',
         ]));
     }
 
@@ -551,17 +551,17 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'regex' => [
                         'regex'   => '^who(o*)$',
-                        'message' => 'You did not provide a valid screech.'
-                    ]
-                ]
-            ]
+                        'message' => 'You did not provide a valid screech.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'screech' => 'whooooooooo'
+            'screech' => 'whooooooooo',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -571,11 +571,11 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'screech' => 'whoot'
+            'screech' => 'whoot',
         ]));
 
         $this->assertFalse($validator->validate([
-            'screech' => 'ribbit'
+            'screech' => 'ribbit',
         ]));
     }
 
@@ -586,17 +586,17 @@ class ServerSideValidatorTest extends TestCase
             'species' => [
                 'validators' => [
                     'required' => [
-                        'message' => 'Please tell us your species.'
-                    ]
-                ]
-            ]
+                        'message' => 'Please tell us your species.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'species' => 'Athene noctua'
+            'species' => 'Athene noctua',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -606,7 +606,7 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertFalse($validator->validate([
-            'species' => ''
+            'species' => '',
         ]));
 
         $this->assertFalse($validator->validate([]));
@@ -619,17 +619,17 @@ class ServerSideValidatorTest extends TestCase
             'phone' => [
                 'validators' => [
                     'telephone' => [
-                        'message' => 'Whoa there, check your phone number again.'
-                    ]
-                ]
-            ]
+                        'message' => 'Whoa there, check your phone number again.',
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'phone' => '1(212)-999-2345'
+            'phone' => '1(212)-999-2345',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -639,23 +639,23 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertTrue($validator->validate([
-            'phone' => '212 999 2344'
+            'phone' => '212 999 2344',
         ]));
 
         $this->assertTrue($validator->validate([
-            'phone' => '212-999-0983'
+            'phone' => '212-999-0983',
         ]));
 
         $this->assertFalse($validator->validate([
-            'phone' => '111-123-5434'
+            'phone' => '111-123-5434',
         ]));
 
         $this->assertFalse($validator->validate([
-            'phone' => '212 123 4567'
+            'phone' => '212 123 4567',
         ]));
 
         $this->assertFalse($validator->validate([
-            'phone' => ''
+            'phone' => '',
         ]));
     }
 
@@ -666,17 +666,17 @@ class ServerSideValidatorTest extends TestCase
             'website' => [
                 'validators' => [
                     'uri' => [
-                        'message' => "That's not even a valid URL..."
-                    ]
-                ]
-            ]
+                        'message' => "That's not even a valid URL...",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'website' => 'http://www.owlfancy.com'
+            'website' => 'http://www.owlfancy.com',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -686,28 +686,28 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertTrue($validator->validate([
-            'website' => 'http://owlfancy.com'
+            'website' => 'http://owlfancy.com',
         ]));
 
         $this->assertTrue($validator->validate([
-            'website' => 'https://learn.userfrosting.com'
+            'website' => 'https://learn.userfrosting.com',
         ]));
 
         // Note that we require URLs to begin with http(s)://
         $this->assertFalse($validator->validate([
-            'website' => 'www.owlfancy.com'
+            'website' => 'www.owlfancy.com',
         ]));
 
         $this->assertFalse($validator->validate([
-            'website' => 'owlfancy.com'
+            'website' => 'owlfancy.com',
         ]));
 
         $this->assertFalse($validator->validate([
-            'website' => 'owls'
+            'website' => 'owls',
         ]));
 
         $this->assertFalse($validator->validate([
-            'website' => ''
+            'website' => '',
         ]));
     }
 
@@ -718,17 +718,17 @@ class ServerSideValidatorTest extends TestCase
             'user_name' => [
                 'validators' => [
                     'username' => [
-                        'message' => "Sorry buddy, that's not a valid username."
-                    ]
-                ]
-            ]
+                        'message' => "Sorry buddy, that's not a valid username.",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
         $validator = new ServerSideValidator($schema, $this->translator);
 
         $result = $validator->validate([
-            'user_name' => 'alex.weissman'
+            'user_name' => 'alex.weissman',
         ]);
 
         // Check that the correct Valitron rule was generated
@@ -738,28 +738,28 @@ class ServerSideValidatorTest extends TestCase
         $this->assertTrue($result);
 
         $this->assertTrue($validator->validate([
-            'user_name' => 'alexweissman'
+            'user_name' => 'alexweissman',
         ]));
 
         $this->assertTrue($validator->validate([
-            'user_name' => 'alex-weissman-the-wise'
+            'user_name' => 'alex-weissman-the-wise',
         ]));
 
         // Note that we require URLs to begin with http(s)://
         $this->assertFalse($validator->validate([
-            'user_name' => "<script>alert('I got you');</script>"
+            'user_name' => "<script>alert('I got you');</script>",
         ]));
 
         $this->assertFalse($validator->validate([
-            'user_name' => '#owlfacts'
+            'user_name' => '#owlfacts',
         ]));
 
         $this->assertFalse($validator->validate([
-            'user_name' => 'Did you ever hear the tragedy of Darth Plagueis the Wise?'
+            'user_name' => 'Did you ever hear the tragedy of Darth Plagueis the Wise?',
         ]));
 
         $this->assertFalse($validator->validate([
-            'user_name' => ''
+            'user_name' => '',
         ]));
     }
 
@@ -771,10 +771,10 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'required' => [
                         'domain'  => 'client',
-                        'message' => "Are you sure you don't want to show us your plumage?"
-                    ]
-                ]
-            ]
+                        'message' => "Are you sure you don't want to show us your plumage?",
+                    ],
+                ],
+            ],
         ]);
 
         // Act
@@ -797,10 +797,10 @@ class ServerSideValidatorTest extends TestCase
                 'validators' => [
                     'required' => [
                         'domain'  => 'server',
-                        'message' => "Are you sure you don't want to show us your plumage?"
-                    ]
-                ]
-            ]
+                        'message' => "Are you sure you don't want to show us your plumage?",
+                    ],
+                ],
+            ],
         ]);
 
         // Act


### PR DESCRIPTION
- Fix error if custom validator doesn't provides a message.
- Removed broken and deprecated `RequestSchema::loadSchema` method.
- 100% Test coverage ([#24])